### PR TITLE
fix: replace usage of python internal EnvironmentVarGuard with unittest mock

### DIFF
--- a/torax/tests/sim_no_compile.py
+++ b/torax/tests/sim_no_compile.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 """Tests that TORAX can be run with compilation disabled."""
+import os
 from typing import Optional, Sequence
+from unittest.mock import patch
 
 from absl.testing import absltest
 from absl.testing import parameterized
-from test.support import os_helper
 from torax.tests.test_lib import sim_test_case
 
 
@@ -56,8 +57,7 @@ class SimTest(sim_test_case.SimTestCase):
       use_ref_time: bool = False,
   ):
     """No-compilation version of integration tests."""
-    with os_helper.EnvironmentVarGuard() as env:
-      env.set('TORAX_COMPILATION_ENABLED', 'False')
+    with patch.dict(os.environ, {'TORAX_COMPILATION_ENABLED': 'False'}):
       self._test_torax_sim(
           config_name,
           profiles,


### PR DESCRIPTION
Running the tests locally was failing for me because the test in `torax/tests/sim_no_compile.py` was throwing an import error on:

```
from test.support import os_helper
```


The python interpreter I used is from the [standalone python](https://github.com/indygreg/python-build-standalone) project. Their python built doesn't include the `test` module.

Note that the docs of the [test](https://docs.python.org/3/library/test.html) module say:

> The [test](https://docs.python.org/3/library/test.html#module-test) package is meant for internal use by Python only. It is documented for the benefit of the core developers of Python. Any use of this package outside of Python’s standard library is discouraged as code mentioned here can change or be removed without notice between releases of Python.

Patching the environment variable in the affected test can easily be done with the `unittest` library from stdlib which avoids running into the above problem.

