### PR TITLE
Add absorption_fraction to generic heat source with injected power tr…

### DIFF
--- a/torax/sim.py
+++ b/torax/sim.py
@@ -236,6 +236,8 @@ def _run_simulation(
   )
 
   sim_state = initial_state
+  # Add the dynamic_runtime_params_slice to the sim_state
+  sim_state.dynamic_runtime_params_slice = dynamic_runtime_params_slice
   sim_history = []
   sim_state = post_processing.make_outputs(sim_state=sim_state, geo=geo)
   sim_history.append(sim_state)
@@ -267,6 +269,17 @@ def _run_simulation(
           geometry_provider,
           sim_state,
       )
+      
+      # Update the dynamic_runtime_params_slice for the current time step
+      dynamic_runtime_params_slice, geo = (
+          build_runtime_params.get_consistent_dynamic_runtime_params_slice_and_geometry(
+              t=sim_state.t,
+              dynamic_runtime_params_slice_provider=dynamic_runtime_params_slice_provider,
+              geometry_provider=geometry_provider,
+          )
+      )
+      sim_state.dynamic_runtime_params_slice = dynamic_runtime_params_slice
+      
       wall_clock_step_times.append(time.time() - step_start_time)
 
       # Checks if sim_state is valid. If not, exit simulation early.

--- a/torax/sim.py
+++ b/torax/sim.py
@@ -236,14 +236,13 @@ def _run_simulation(
   )
 
   sim_state = initial_state
-  # Add the dynamic_runtime_params_slice to the sim_state
-  sim_state.dynamic_runtime_params_slice = dynamic_runtime_params_slice
   sim_history = []
-  sim_state = post_processing.make_outputs(sim_state=sim_state, geo=geo)
+  sim_state = post_processing.make_outputs(
+      sim_state=sim_state, geo=geo, dynamic_runtime_params_slice=dynamic_runtime_params_slice
+  )
   sim_history.append(sim_state)
 
-  # Set the sim_error to NO_ERROR. If we encounter an error, we will set it to
-  # the appropriate error code.
+  # Simulation exit logic is specified by the TimeStepCalculator.
   sim_error = state.SimError.NO_ERROR
 
   with tqdm.tqdm(
@@ -278,7 +277,6 @@ def _run_simulation(
               geometry_provider=geometry_provider,
           )
       )
-      sim_state.dynamic_runtime_params_slice = dynamic_runtime_params_slice
       
       wall_clock_step_times.append(time.time() - step_start_time)
 

--- a/torax/sources/generic_ion_el_heat_source.py
+++ b/torax/sources/generic_ion_el_heat_source.py
@@ -140,9 +140,7 @@ class GenericIonElHeatSourceConfig(base.SourceModelBase):
   el_heat_fraction: torax_pydantic.TimeVaryingScalar = (
       torax_pydantic.ValidatedDefault(0.66666)
   )
-  # TODO: Add appropriate pydantic validation for absorption_fraction
-  # to ensure it's never below a small positive value to prevent division by zero.
-  absorption_fraction: torax_pydantic.TimeVaryingScalar = (
+  absorption_fraction: torax_pydantic.PositiveTimeVaryingScalar = (
       torax_pydantic.ValidatedDefault(1.0)
   )
   mode: runtime_params_lib.Mode = runtime_params_lib.Mode.MODEL_BASED

--- a/torax/sources/ion_cyclotron_source.py
+++ b/torax/sources/ion_cyclotron_source.py
@@ -453,9 +453,11 @@ class IonCyclotronSourceConfig(base.SourceModelBase):
   """Configuration for the IonCyclotronSource.
 
   Attributes:
-    wall_inner: Inner wall radial position [m].
-    wall_outer: Outer wall radial position [m].
-    frequency: RF frequency [Hz].
+    wall_inner: Inner radial location of first wall at plasma midplane level
+      [m].
+    wall_outer: Outer radial location of first wall at plasma midplane level
+      [m].
+    frequency: ICRF wave frequency [Hz].
     minority_concentration: He3 minority concentration relative to the electron
       density in %.
     Ptot: Total heating power [W].
@@ -472,9 +474,7 @@ class IonCyclotronSourceConfig(base.SourceModelBase):
       torax_pydantic.ValidatedDefault(3.0)
   )
   Ptot: torax_pydantic.TimeVaryingScalar = torax_pydantic.ValidatedDefault(10e6)
-  # TODO: Add appropriate pydantic validation for absorption_fraction
-  # to ensure it's never below a small positive value to prevent division by zero.
-  absorption_fraction: torax_pydantic.TimeVaryingScalar = (
+  absorption_fraction: torax_pydantic.PositiveTimeVaryingScalar = (
       torax_pydantic.ValidatedDefault(1.0)
   )
   mode: runtime_params_lib.Mode = runtime_params_lib.Mode.MODEL_BASED

--- a/torax/sources/tests/constant_fraction_impurity_radiation_heat_sink_test.py
+++ b/torax/sources/tests/constant_fraction_impurity_radiation_heat_sink_test.py
@@ -60,6 +60,7 @@ class ImpurityRadiationConstantFractionTest(
         w=0.25,
         Ptot=120e6,
         el_heat_fraction=0.66666,
+        absorption_fraction=1.0,
     )
 
     static = runtime_params_lib.StaticRuntimeParams(

--- a/torax/state.py
+++ b/torax/state.py
@@ -345,6 +345,7 @@ class PostProcessedOutputs:
     P_external_el: Total external electron heating power: auxiliary heating +
       Ohmic [W]
     P_external_tot: Total external heating power: auxiliary heating + Ohmic [W]
+    P_external_injected: Total external injected power before absorption [W]
     P_ei_exchange_ion: Electron-ion heat exchange power to ions [W]
     P_ei_exchange_el: Electron-ion heat exchange power to electrons [W]
     P_generic_ion: Total generic_ion_el_heat_source power to ions [W]
@@ -412,6 +413,7 @@ class PostProcessedOutputs:
   P_external_ion: array_typing.ScalarFloat
   P_external_el: array_typing.ScalarFloat
   P_external_tot: array_typing.ScalarFloat
+  P_external_injected: array_typing.ScalarFloat
   P_ei_exchange_ion: array_typing.ScalarFloat
   P_ei_exchange_el: array_typing.ScalarFloat
   P_generic_ion: array_typing.ScalarFloat
@@ -476,6 +478,7 @@ class PostProcessedOutputs:
         P_external_ion=jnp.array(0.0),
         P_external_el=jnp.array(0.0),
         P_external_tot=jnp.array(0.0),
+        P_external_injected=jnp.array(0.0),
         P_ei_exchange_ion=jnp.array(0.0),
         P_ei_exchange_el=jnp.array(0.0),
         P_generic_ion=jnp.array(0.0),

--- a/torax/state.py
+++ b/torax/state.py
@@ -594,8 +594,6 @@ class ToraxSimState:
     geometry: Geometry at this time step used for the simulation.
     time_step_calculator_state: the state of the TimeStepper.
     stepper_numeric_outputs: Numerical quantities related to the stepper.
-    dynamic_runtime_params_slice: Runtime parameters that can change without
-      requiring recompilation, used for integration with the sources.
   """
 
   # Time variables.
@@ -617,9 +615,6 @@ class ToraxSimState:
   # TORAX.
   time_step_calculator_state: Any
   stepper_numeric_outputs: StepperNumericOutputs
-  
-  # Runtime parameters that can vary without recompilation
-  dynamic_runtime_params_slice: Optional[runtime_params_slice.DynamicRuntimeParamsSlice] = None
 
   def check_for_errors(self) -> SimError:
     """Checks for errors in the simulation state."""

--- a/torax/state.py
+++ b/torax/state.py
@@ -15,14 +15,14 @@
 """Classes defining the TORAX state that evolves over time."""
 import dataclasses
 import enum
-from typing import Any, Optional
+from typing import Any, Optional, Mapping, Sequence, TypeVar, Union, cast
 
 from absl import logging
 import chex
 import jax
 from jax import numpy as jnp
 from torax import array_typing
-from torax.config import config_args
+from torax.config import config_args, runtime_params_slice
 from torax.fvm import cell_variable
 from torax.geometry import geometry
 from torax.sources import source_profiles
@@ -594,6 +594,8 @@ class ToraxSimState:
     geometry: Geometry at this time step used for the simulation.
     time_step_calculator_state: the state of the TimeStepper.
     stepper_numeric_outputs: Numerical quantities related to the stepper.
+    dynamic_runtime_params_slice: Runtime parameters that can change without
+      requiring recompilation, used for integration with the sources.
   """
 
   # Time variables.
@@ -615,6 +617,9 @@ class ToraxSimState:
   # TORAX.
   time_step_calculator_state: Any
   stepper_numeric_outputs: StepperNumericOutputs
+  
+  # Runtime parameters that can vary without recompilation
+  dynamic_runtime_params_slice: Optional[runtime_params_slice.DynamicRuntimeParamsSlice] = None
 
   def check_for_errors(self) -> SimError:
     """Checks for errors in the simulation state."""

--- a/torax/tests/post_processing_test.py
+++ b/torax/tests/post_processing_test.py
@@ -47,6 +47,8 @@ class PostProcessingTest(parameterized.TestCase):
             sources=sources,
         )
     )
+    # Save dynamic_runtime_params_slice for test_calculate_integrated_sources
+    self.dynamic_runtime_params_slice = dynamic_runtime_params_slice
     # Make some dummy source profiles.
     ones = np.ones_like(geo.rho)
     self.source_profiles = source_profiles_lib.SourceProfiles(

--- a/torax/tests/post_processing_test.py
+++ b/torax/tests/post_processing_test.py
@@ -128,6 +128,7 @@ class PostProcessingTest(parameterized.TestCase):
         self.geo,
         self.core_profiles,
         self.source_profiles,
+        self.dynamic_runtime_params_slice,
     )
     # pylint: enable=protected-access
 
@@ -149,6 +150,7 @@ class PostProcessingTest(parameterized.TestCase):
         'P_external_ion',
         'P_external_el',
         'P_external_tot',
+        'P_external_injected',
         'I_ecrh',
         'I_generic',
     }

--- a/torax/tests/run_simulation_main_test.py
+++ b/torax/tests/run_simulation_main_test.py
@@ -104,6 +104,13 @@ class RunSimulationMainTest(parameterized.TestCase):
     reference = output_lib.load_state_file(
         os.path.join(paths.test_data_dir(), "test_implicit.nc")
     )
+    
+    # Before checking equality, remove P_external_injected which is new and not in reference
+    if 'post_processed_outputs' in output:
+      post_processed = output['post_processed_outputs']
+      if 'P_external_injected' in post_processed:
+        output['post_processed_outputs'] = post_processed.drop_vars('P_external_injected')
+    
     xr.map_over_datasets(xr.testing.assert_allclose, output, reference)
 
   @flagsaver.flagsaver(

--- a/torax/tests/run_simulation_main_test.py
+++ b/torax/tests/run_simulation_main_test.py
@@ -109,7 +109,8 @@ class RunSimulationMainTest(parameterized.TestCase):
     if 'post_processed_outputs' in output:
       post_processed = output['post_processed_outputs']
       if 'P_external_injected' in post_processed:
-        output['post_processed_outputs'] = post_processed.drop_vars('P_external_injected')
+        # DataTree objects don't have drop_vars method
+        del post_processed['P_external_injected']
     
     xr.map_over_datasets(xr.testing.assert_allclose, output, reference)
 
@@ -146,7 +147,9 @@ class RunSimulationMainTest(parameterized.TestCase):
     after = os.path.join(test_data_dir, "test_changing_config_after.py")
     # Copy the "before" config to the active location
     shutil.copy(before, in_use)
-    os.sync()
+    # os.sync() is not available on Windows, so we'll skip it
+    if hasattr(os, 'sync'):
+      os.sync()
 
     # Redirect stdout to this string buffer
     captured_stdout = io.StringIO()
@@ -169,7 +172,9 @@ class RunSimulationMainTest(parameterized.TestCase):
         # changed config, then send the 'cc' response
         os.remove(in_use)
         shutil.copy(after, in_use)
-        os.sync()
+        # os.sync() is not available on Windows, so we'll skip it
+        if hasattr(os, 'sync'):
+          os.sync()
         response = "mc"
       elif call_count == 1:
         self.assertEqual(prompt, run_simulation_main.Y_N_PROMPT)

--- a/torax/tests/run_simulation_main_test.py
+++ b/torax/tests/run_simulation_main_test.py
@@ -218,6 +218,10 @@ class RunSimulationMainTest(parameterized.TestCase):
           self.assertIn(key, ds1)
 
         for key in ds1:
+          # Skip the P_external_injected field that exists in output but not reference
+          if key == 'P_external_injected':
+            continue
+            
           self.assertIn(key, ds2)
 
           ov = ds2[key].to_numpy()


### PR DESCRIPTION
The changes in this branch include:
Added absorption_fraction parameter to DynamicRuntimeParams in generic_ion_el_heat_source.py
Modified calc_generic_heat_source to apply absorption_fraction to power calculation
Added P_external_injected tracking in post_processing.py
Updated Q fusion calculation to use injected power instead of absorbed power
Added corresponding changes to ion_cyclotron_source.py for consistency
![Screenshot 2025-03-20 123951](https://github.com/user-attachments/assets/45b1fb89-a86c-41b5-ba7f-948a7e8d4346)
