### PR TITLE
Bump version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "torax"
 description = "Differentiable 1D tokamak plasma transport simulator in JAX."
-version = "0.1.0"
+version = "0.3.0.dev"
 readme = "README.md"
 requires-python = ">=3.10"
 license = {file = "LICENSE"}


### PR DESCRIPTION
I noticed that the reported version in python is still `0.1.0` since the pyproject.toml hasn't been updated.

Bumping this to `0.3.0.dev` to indicate the current dev window. Would be nice if we can then bump this again just before the next tagged release.