### PR TITLE
Plot total transport coefficients in default_plot_config

### DIFF
--- a/torax/_src/plotting/plotruns_lib.py
+++ b/torax/_src/plotting/plotruns_lib.py
@@ -126,13 +126,35 @@ class PlotData:
       [:math:`\mathrm{MA/m^2}`] on the cell grid.
     q: Safety factor (q-profile) [dimensionless] on the face grid.
     magnetic_shear: Magnetic shear profile [dimensionless] on the face grid.
-    chi_turb_i: Ion heat conductivity [:math:`\mathrm{m^2/s}`] on the face grid.
-    chi_turb_e: Electron heat conductivity [:math:`\mathrm{m^2/s}`] on the face
-      grid.
-    D_turb_e: Electron particle diffusivity [:math:`\mathrm{m^2/s}`] on the face
-      grid.
-    V_turb_e: Electron particle convection velocity [:math:`\mathrm{m/s}`] on
+    chi_tot_i: Total ion heat conductivity (chi_turb_i + chi_neo_i)
+      [:math:`\mathrm{m^2/s}`] on the face grid.
+    chi_turb_i: Turbulent ion heat conductivity [:math:`\mathrm{m^2/s}`] on the
+      face grid.
+    chi_neo_i: Neoclassical ion heat conductivity [:math:`\mathrm{m^2/s}`] on
       the face grid.
+    chi_tot_e: Total electron heat conductivity (chi_turb_e + chi_neo_e)
+      [:math:`\mathrm{m^2/s}`] on the face grid.
+    chi_turb_e: Turbulent electron heat conductivity [:math:`\mathrm{m^2/s}`]
+      on the face grid.
+    chi_neo_e: Neoclassical electron heat conductivity [:math:`\mathrm{m^2/s}`]
+      on the face grid.
+    D_tot_e: Total electron particle diffusivity (D_turb_e + D_neo_e)
+      [:math:`\mathrm{m^2/s}`] on the face grid.
+    D_turb_e: Turbulent electron particle diffusivity [:math:`\mathrm{m^2/s}`]
+      on the face grid.
+    D_neo_e: Neoclassical electron particle diffusivity [:math:`\mathrm{m^2/s}`]
+      on the face grid.
+    V_tot_e: Total electron particle convection (V_turb_e + V_neo_e +
+      V_neo_ware_e) [:math:`\mathrm{m^2/s}`] on the face grid.
+    V_turb_e: Turbulent electron particle convection [:math:`\mathrm{m^2/s}`]
+      on the face grid.
+    V_neo_tot_e: Neoclassical electron particle convection
+      [:math:`\mathrm{m^2/s}`] on the face grid. Contains all components
+      including the Ware pinch.
+    V_neo_e: Neoclassical electron particle convection [:math:`\mathrm{m^2/s}`]
+      on the face grid. Contains all components apart from the Ware pinch.
+    V_neo_ware_e: Neoclassical electron particle convection (Ware pinch term)
+      [:math:`\mathrm{m^2/s}`] on the face grid.
     p_icrh_i: ICRH ion heating power density [:math:`\mathrm{MW/m^3}`].
     p_icrh_e: ICRH electron heating power density [:math:`\mathrm{MW/m^3}`].
     p_generic_heat_i: Generic ion heating power density
@@ -204,10 +226,20 @@ class PlotData:
   j_external: np.ndarray
   q: np.ndarray
   magnetic_shear: np.ndarray
+  chi_tot_i: np.ndarray
   chi_turb_i: np.ndarray
+  chi_neo_i: np.ndarray
+  chi_tot_e: np.ndarray
   chi_turb_e: np.ndarray
+  chi_neo_e: np.ndarray
+  D_tot_e: np.ndarray
   D_turb_e: np.ndarray
+  D_neo_e: np.ndarray
+  V_tot_e: np.ndarray
   V_turb_e: np.ndarray
+  V_neo_tot_e: np.ndarray
+  V_neo_e: np.ndarray
+  V_neo_ware_e: np.ndarray
   p_icrh_i: np.ndarray
   p_icrh_e: np.ndarray
   p_generic_heat_i: np.ndarray
@@ -339,10 +371,26 @@ def load_data(filename: str) -> PlotData:
       ),
       q=profiles_dataset[output.Q].to_numpy(),
       magnetic_shear=profiles_dataset[output.MAGNETIC_SHEAR].to_numpy(),
+      chi_tot_i=profiles_dataset[output.CHI_TURB_I].to_numpy()
+      + profiles_dataset[output.CHI_NEO_I].to_numpy(),
       chi_turb_i=profiles_dataset[output.CHI_TURB_I].to_numpy(),
+      chi_neo_i=profiles_dataset[output.CHI_NEO_I].to_numpy(),
+      chi_tot_e=profiles_dataset[output.CHI_TURB_E].to_numpy()
+      + profiles_dataset[output.CHI_NEO_E].to_numpy(),
       chi_turb_e=profiles_dataset[output.CHI_TURB_E].to_numpy(),
+      chi_neo_e=profiles_dataset[output.CHI_NEO_E].to_numpy(),
+      D_tot_e=profiles_dataset[output.D_TURB_E].to_numpy()
+      + profiles_dataset[output.D_NEO_E].to_numpy(),
       D_turb_e=profiles_dataset[output.D_TURB_E].to_numpy(),
+      D_neo_e=profiles_dataset[output.D_NEO_E].to_numpy(),
+      V_tot_e=profiles_dataset[output.V_TURB_E].to_numpy()
+      + profiles_dataset[output.V_NEO_E].to_numpy()
+      + profiles_dataset[output.V_NEO_WARE_E].to_numpy(),
       V_turb_e=profiles_dataset[output.V_TURB_E].to_numpy(),
+      V_neo_tot_e=profiles_dataset[output.V_NEO_E].to_numpy()
+      + profiles_dataset[output.V_NEO_WARE_E].to_numpy(),
+      V_neo_e=profiles_dataset[output.V_NEO_E].to_numpy(),
+      V_neo_ware_e=profiles_dataset[output.V_NEO_WARE_E].to_numpy(),
       rho_norm=dataset[output.RHO_NORM].to_numpy(),
       rho_cell_norm=dataset[output.RHO_CELL_NORM].to_numpy(),
       rho_face_norm=dataset[output.RHO_FACE_NORM].to_numpy(),

--- a/torax/plotting/configs/default_plot_config.py
+++ b/torax/plotting/configs/default_plot_config.py
@@ -39,16 +39,28 @@ PLOT_CONFIG = plotruns_lib.FigureProperties(
             ylabel=r'Density $[10^{20}~m^{-3}]$',
         ),
         plotruns_lib.PlotProperties(
-            attrs=('chi_turb_i', 'chi_turb_e'),
-            labels=(r'$\chi_\mathrm{i}$', r'$\chi_\mathrm{e}$'),
+            attrs=(
+                'chi_tot_i',
+                'chi_tot_e',
+            ),
+            labels=(
+                r'$\chi_\mathrm{i}$',
+                r'$\chi_\mathrm{e}$',
+            ),
             ylabel=r'Heat conductivity $[m^2/s]$',
             upper_percentile=98.0,
             include_first_timepoint=False,
             ylim_min_zero=False,
         ),
         plotruns_lib.PlotProperties(
-            attrs=('D_turb_e', 'V_turb_e'),
-            labels=(r'$D_\mathrm{e}$', r'$V_\mathrm{e}$'),
+            attrs=(
+                'D_tot_e',
+                'V_tot_e',
+            ),
+            labels=(
+                r'$D_\mathrm{e}$',
+                r'$V_\mathrm{e}$',
+            ),
             ylabel=r'Diff $[m^2/s]$ or Conv $[m/s]$',
             upper_percentile=98.0,
             lower_percentile=2.0,

--- a/torax/plotting/configs/transport_plot_config.py
+++ b/torax/plotting/configs/transport_plot_config.py
@@ -1,0 +1,100 @@
+# Copyright 2024 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Plotting configuration for Torax runs focusing on transport coefficients."""
+
+from torax._src.plotting import plotruns_lib
+
+PLOT_CONFIG = plotruns_lib.FigureProperties(
+    rows=2,
+    cols=3,
+    tick_fontsize=10,
+    axes_fontsize=10,
+    default_legend_fontsize=9,
+    figure_size_factor=5,
+    title_fontsize=12,
+    axes=(
+        plotruns_lib.PlotProperties(
+            attrs=(
+                'chi_turb_i',
+                'chi_turb_e',
+            ),
+            labels=(
+                r'$\chi_\mathrm{turb,i}$',
+                r'$\chi_\mathrm{turb,e}$',
+            ),
+            ylabel=r'Turbulent heat conductivity $[m^2/s]$',
+            upper_percentile=98.0,
+            include_first_timepoint=False,
+            ylim_min_zero=False,
+        ),
+        plotruns_lib.PlotProperties(
+            attrs=('D_turb_e',),
+            labels=(r'$D_\mathrm{turb,e}$',),
+            ylabel=r'Turbulent particle diffusivity $[m^2/s]$$',
+            upper_percentile=98.0,
+            lower_percentile=2.0,
+            include_first_timepoint=False,
+            ylim_min_zero=False,
+        ),
+        plotruns_lib.PlotProperties(
+            attrs=('V_turb_e',),
+            labels=(r'$V_\mathrm{turb,e}$',),
+            ylabel=r'Turbulent particle convectivity $[m^2/s]$$',
+            upper_percentile=98.0,
+            lower_percentile=2.0,
+            include_first_timepoint=False,
+            ylim_min_zero=False,
+        ),
+        plotruns_lib.PlotProperties(
+            attrs=(
+                'chi_neo_i',
+                'chi_neo_e',
+            ),
+            labels=(
+                r'$\chi_\mathrm{neo,i}$',
+                r'$\chi_\mathrm{neo,e}$',
+            ),
+            ylabel=r'Neoclassical heat conductivity $[m^2/s]$',
+            upper_percentile=98.0,
+            include_first_timepoint=False,
+            ylim_min_zero=False,
+            suppress_zero_values=True,
+        ),
+        plotruns_lib.PlotProperties(
+            attrs=('D_neo_e',),
+            labels=(r'$D_\mathrm{neo,e}$',),
+            ylabel=r'Neoclassical particle diffusivity $[m^2/s]$$',
+            upper_percentile=98.0,
+            lower_percentile=2.0,
+            include_first_timepoint=False,
+            ylim_min_zero=False,
+            suppress_zero_values=True,
+        ),
+        plotruns_lib.PlotProperties(
+            attrs=('V_neo_tot_e', 'V_neo_e', 'V_neo_ware_e'),
+            labels=(
+                r'$V_\mathrm{neo,e}+V_\mathrm{ware,e}$',
+                r'$V_\mathrm{neo,e}$',
+                r'$V_\mathrm{ware,e}$',
+            ),
+            ylabel=r'Neoclassical particle convectivity $[m^2/s]$$',
+            upper_percentile=98.0,
+            lower_percentile=2.0,
+            include_first_timepoint=False,
+            ylim_min_zero=False,
+            suppress_zero_values=True,
+        ),
+    ),
+)


### PR DESCRIPTION
Given the addition of neoclassical transport, I've found it useful to modify the plot config so that the total and turbulent transport coefficients are both plotted. If there's a different combination that would be more useful, let me know and I can change it!