### PR TITLE
Log nans from post-processed outputs

### DIFF
--- a/torax/_src/orchestration/sim_state.py
+++ b/torax/_src/orchestration/sim_state.py
@@ -85,7 +85,7 @@ def _log_nans(
   nan_count = 0
   for path, value in path_vals:
     if np.any(np.isnan(value)):
-      logging.info("Found NaNs in %s", jax.tree_util.keystr(path))
+      logging.info("Found NaNs in sim_state%s", jax.tree_util.keystr(path))
       nan_count += 1
   if nan_count >= 10:
     logging.info("""\nA common cause of widespread NaNs is negative densities or

--- a/torax/_src/output_tools/post_processing.py
+++ b/torax/_src/output_tools/post_processing.py
@@ -16,6 +16,7 @@
 import dataclasses
 from typing import Callable
 
+from absl import logging
 import jax
 from jax import numpy as jnp
 import numpy as np
@@ -324,6 +325,13 @@ class PostProcessedOutputs:
 
   def check_for_errors(self):
     if any([np.any(np.isnan(x)) for x in jax.tree.leaves(self)]):
+      path_vals, _ = jax.tree.flatten_with_path(self)
+      for path, value in path_vals:
+        if np.any(np.isnan(value)):
+          logging.info(
+              'Found NaNs in post_processed_outputs%s',
+              jax.tree_util.keystr(path),
+          )
       return state.SimError.NAN_DETECTED
     else:
       return state.SimError.NO_ERROR

--- a/torax/_src/state.py
+++ b/torax/_src/state.py
@@ -263,7 +263,7 @@ class SimError(enum.Enum):
             """)
       case SimError.NAN_DETECTED:
         logging.error("""
-            Simulation stopped due to NaNs in state.
+            Simulation stopped due to NaNs in state and/or post processed outputs.
             Output file contains all profiles up to the last valid step.
             """)
       case SimError.QUASINEUTRALITY_BROKEN:


### PR DESCRIPTION
Previously, there was logging for nans from sim_state but not from post_processed outputs.