### PR TITLE
Fix typo in comment: 'Explictly' → 'Explicitly'

### DIFF
--- a/torax/_src/sources/tests/impurity_radiation_mavrin_fit_test.py
+++ b/torax/_src/sources/tests/impurity_radiation_mavrin_fit_test.py
@@ -330,7 +330,7 @@ class MarvinImpurityRadiationHeatSinkTest(test_lib.SingleProfileSourceTestCase):
     n_impurities_true = {
         symbol: ratio * n_e_true for symbol, ratio in impurity_ratios.items()
     }
-    # Explictly assumes that Z_i = 1.0
+    # Explicitly assumes that Z_i = 1.0
     ni_true = n_e_true - sum(
         n_imp * z_imp
         for n_imp, z_imp in zip(


### PR DESCRIPTION
This PR fixes a small typo in a comment in 

`torax_src/sources/tests/impurity_radiation_mavrin_fit_test.py`:

- incorrect:  `"Explictly"`
- correct: `"Explicitly"`

No functional code changes

Closes #1585
