### PR TITLE
Ignore sim_experimental_compile_test.py in pytest configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ addopts = [
     "--ignore-glob=*lib*",
     # Leads to an ImportError in collection for `pytest` without qualikiz_tools.
     "--ignore=torax/_src/transport_model/qualikiz_wrapper.py",
+    "--ignore=torax/tests/sim_experimental_compile_test.py"
 ]
 testpaths = "**/tests"
 python_files = "*.py"


### PR DESCRIPTION
As suggested by the maintainer in [this comment](https://github.com/google-deepmind/torax/issues/1572#issuecomment-3311477175), this PR updates the pytest configuration in pyproject.toml to ignore `torax/tests/sim_experimental_compile_test.py`.

This prevents test capture errors until the file is removed internally.