### PR TITLE
Document required environment variables for pytest in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,15 @@ run_torax  --config='examples/iterhybrid_rampup.py' --log_progress
 
 #### Set environment variables
 
+##### Running Tests with Full Assertion Checks
+
+To run the pytest test suite with all assertion checks enabled, set the following environment variables:
+
+```shell
+$ export TORAX_JAXTYPING=True
+$ export TORAX_ERRORS_ENABLED=True
+```
+
 ##### Error checking
 
 If true, error checking is enabled in internal routines. Used for debugging.


### PR DESCRIPTION
This PR addresses the first point of [this comment](https://github.com/google-deepmind/torax/issues/1572#issuecomment-3311477175)

- Adds a section under "Set environment variables" in README.md.
- Informs contributors to set the following environment variables when running pytest:
  - TORAX_JAXTYPING=True
  - TORAX_ERRORS_ENABLED=True
- Ensures that all assertion and error checks are active during testing.