### PR TITLE
plasma_composition converter for imas core_profiles

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -2092,10 +2092,11 @@ saved in Data Dictionary version 4.0.0 or newer.
 If the IDS is stored in an IMAS db or in a netCDF file it can be loaded using
 the loader function ``load_imas_data`` from |imas_loader|.
 It can then be loaded programatically in the ``CONFIG`` by constructing a nested
-dictionary with the ``core_profiles_from_imas`` function from
-|core_profiles_input_imas|. The function returns a dictionary whose structure
-fits the schema of profile_conditions and can be programatically loaded into a
-``CONFIG`` with standard dictionary manipulation.
+dictionary with the ``profile_conditions_from_imas`` and
+``plasma_composition_from_imas`` functions from |core_profiles_input_imas|. The
+functions returns a dictionary whose structure fits the schema of 
+profile_conditions or plasma_composition and can be programatically loaded into
+a ``CONFIG`` with standard dictionary manipulation.
 
 An example on how to inject the IMAS conditions into the config can be found in
 the test file ``imas_tools/input/tests/core_profiles_test.py``.

--- a/torax/_src/constants.py
+++ b/torax/_src/constants.py
@@ -109,3 +109,5 @@ ION_PROPERTIES_DICT: Final[Mapping[str, IonProperties]] = (
 )
 
 ION_SYMBOLS = frozenset(ION_PROPERTIES_DICT.keys())
+
+HYDROGENIC_IONS: Final[frozenset[str]] = frozenset(['H', 'D', 'T'])

--- a/torax/_src/imas_tools/input/core_profiles.py
+++ b/torax/_src/imas_tools/input/core_profiles.py
@@ -12,17 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Useful functions to load IMAS core_profiles or plasma_profiles IDSs."""
-from typing import Any, Mapping
+from typing import Any, Collection
 
 from imas import ids_toplevel
 import numpy as np
+from torax._src import constants
 
 
 # pylint: disable=invalid-name
 def profile_conditions_from_IMAS(
     ids: ids_toplevel.IDSToplevel,
     t_initial: float | None = None,
-) -> Mapping[str, Any]:
+) -> dict[str, Any]:
   """Converts core_profiles IDS to a profile_conditions dict for TORAX config.
 
   Args:
@@ -36,11 +37,9 @@ def profile_conditions_from_IMAS(
     The updated fields read from the IDS that can be used to completely or
     partially fill the `profile_conditions` section of a TORAX `CONFIG`.
   """
-  profiles_1d = ids.profiles_1d
-  time_array = [profile.time for profile in profiles_1d]
-  if t_initial:
-    time_array = [ti - time_array[0] + t_initial for ti in time_array]
-  rhon_array = [profile.grid.rho_tor_norm for profile in profiles_1d]
+  profiles_1d, rhon_array, time_array = _get_time_and_radial_arrays(
+      ids, t_initial
+  )
 
   # profile_conditions
   psi = (np.array(rhon_array[0]), np.array(profiles_1d[0].grid.psi))
@@ -109,3 +108,129 @@ def profile_conditions_from_IMAS(
       "normalize_n_e_to_nbar": False,
       "v_loop_lcfs": v_loop_lcfs,
   }
+
+
+def plasma_composition_from_IMAS(
+    ids: ids_toplevel.IDSToplevel,
+    t_initial: float | None = None,
+    expected_impurities: Collection[str] = None,
+    main_ions_symbols: Collection[str] = constants.HYDROGENIC_IONS,
+) -> dict[str, Any]:
+  """Returns dict with args for plasma_composition config from a given ids.
+
+  plasma_composition dict obtained from IMAS can be used with two impurity
+  modes (contained within the `impurity` key):
+    - `n_e_ratios` - default returned from this function (note Z_eff will be
+    ignored in this case).
+    - `n_e_ratios_Z_eff` - In this case one impurity ratio should be set to
+    None and the `impurity_mode` string overwritten.
+    - `fractions` impurity mode is unsupported.
+  Note that if the input ids does not contain info for the different ion
+  species, the function will not raise an error but return an empty dict for
+  `main_ion` and `species` plasma_composition keys unless the expected species
+  are specified using the expected_impurities and main_ion_symbols args.
+
+  Args:
+    ids: A core_profiles IDS object. The IDS can contain multiple time slices.
+    t_initial: Initial time used to map the profiles in the dicts. If None the
+      initial time will be the time of the first time slice of the ids. Else all
+      time slices will be shifted such that the first time slice has time =
+      t_initial.
+    expected_impurities: Optional arg to check that the input IDS contains the
+      wanted impurity species and raise and error if not, or if its density is
+      empty.
+    main_ions_symbols: collection of ions to be used to define the main_ion
+      mixture. If value is not the default one, will check that the given ions
+      exist in the IDS and their density is filled.
+      Default are hydrogenic ions H, D, T.
+
+  Returns:
+    The updated fields read from the IDS that can be used to completely or
+    partially fill the `plasma_composition` section of a TORAX `CONFIG`.
+  """
+  profiles_1d, rhon_array, time_array = _get_time_and_radial_arrays(
+      ids, t_initial
+  )
+  # Check that the expected ions are present in the IDS
+  ids_ions = [ion.name for ion in profiles_1d[0].ion if ion.density]
+  if expected_impurities:
+    _check_expected_ions_presence(ids_ions, expected_impurities)
+  if main_ions_symbols is not constants.HYDROGENIC_IONS:
+    _check_expected_ions_presence(ids_ions, main_ions_symbols)
+
+  Z_eff = (
+      time_array,
+      rhon_array,
+      [profile.zeff for profile in profiles_1d],
+  )
+  impurity_species = {}
+  main_ion_ratios = {}
+  for ion in range(len(profiles_1d[0].ion)):
+    try:
+      symbol = str(profiles_1d[0].ion[ion].name)
+    except AttributeError:
+      # Case ids is plasma_profiles in early DDv4 releases.
+      symbol = str(profiles_1d[0].ion[ion].label)
+    if symbol in constants.ION_PROPERTIES_DICT.keys():
+      # Fill main ions
+      if symbol in main_ions_symbols:
+        main_ion_ratios[symbol] = [
+            profile.ion[ion].density[0] for profile in profiles_1d
+        ]
+        # Currently take ratios of central density value, would it be more
+        # accurate to take ratios of volume integrated densities ?
+      # Fill impurities
+      else:
+        n_e_ratio = (
+            time_array,
+            rhon_array,
+            [
+                profile.ion[ion].density / profile.electrons.density
+                for profile in profiles_1d
+            ],
+        )
+        impurity_species[symbol] = n_e_ratio
+  total_main_ion_density = np.sum(
+      [ratio for ratio in main_ion_ratios.values()], axis=0
+  )
+  main_ion = {}
+  for symbol, ratio in main_ion_ratios.items():
+    main_ion[symbol] = (time_array, ratio / total_main_ion_density)
+  return {
+      "main_ion": main_ion,
+      "Z_eff": Z_eff,
+      "impurity": {
+          "impurity_mode": "n_e_ratios",
+          "species": impurity_species,
+      },
+  }
+
+
+def _get_time_and_radial_arrays(
+    ids: ids_toplevel.IDSToplevel,
+    t_initial: float | None = None,
+) -> tuple[ids_toplevel.IDSStructure, list[list[float]], list[float]]:
+  profiles_1d = ids.profiles_1d
+  time_array = [profile.time for profile in profiles_1d]
+  if t_initial:
+    time_array = [ti - time_array[0] + t_initial for ti in time_array]
+  rhon_array = [profile.grid.rho_tor_norm for profile in profiles_1d]
+  return profiles_1d, rhon_array, time_array
+
+
+def _check_expected_ions_presence(
+    ids_ions: list[str],
+    expected_ions: Collection[str],
+) -> None:
+  """Checks that the expected_ions symbols are in the ids_ions array."""
+  for ion in expected_ions:
+    if ion not in constants.ION_PROPERTIES_DICT.keys():
+      raise (KeyError(f"{ion} is not a valid symbol of a TORAX valid ion."))
+    if ion not in ids_ions:
+      raise (
+          ValueError(
+              f"The expected ion {ion} cannot be found in the input"
+              " IDS or has no valid data. \n Please check that the IDS is"
+              " properly filled"
+          )
+      )

--- a/torax/_src/imas_tools/input/tests/core_profiles_test.py
+++ b/torax/_src/imas_tools/input/tests/core_profiles_test.py
@@ -107,6 +107,84 @@ class CoreProfilesTest(sim_test_case.SimTestCase):
         err_msg="psi profile failed",
     )
 
+  def test_imas_plasma_composition(self):
+    config = self._get_config_dict("test_iterhybrid_rampup_short.py")
+
+    path = "core_profiles_ddv4_iterhybrid_rampup_conditions.nc"
+    core_profiles_in = loader.load_imas_data(path, "core_profiles")
+    # Indivual ion info empty in the inital IDS so create fake ions data
+    core_profiles_in.profiles_1d[0].ion.resize(3)
+    core_profiles_in.profiles_1d[1].ion.resize(3)
+    core_profiles_in.global_quantities.ion.resize(3)
+    core_profiles_in.profiles_1d[0].ion[0].name = "D"
+    core_profiles_in.profiles_1d[0].ion[0].density = [9e19, 3e19]
+    core_profiles_in.profiles_1d[1].ion[0].density = [9e19, 3e19]
+    core_profiles_in.profiles_1d[0].ion[1].name = "T"
+    core_profiles_in.profiles_1d[0].ion[1].density = [9e19, 3e19]
+    core_profiles_in.profiles_1d[1].ion[1].density = [9e19, 3e19]
+    core_profiles_in.profiles_1d[0].ion[2].name = "Ne"
+    core_profiles_in.profiles_1d[1].ion[2].name = "Ne"
+    core_profiles_in.profiles_1d[0].ion[2].density = (
+        core_profiles_in.profiles_1d[0].electrons.density / 100
+    )
+    core_profiles_in.profiles_1d[1].ion[2].density = (
+        core_profiles_in.profiles_1d[1].electrons.density / 100
+    )
+
+    with self.subTest(name="Missing expected impurity."):
+      self.assertRaises(
+          ValueError,
+          core_profiles.plasma_composition_from_IMAS,
+          core_profiles_in,
+          None,
+          None,
+          ["Xe"],
+      )
+    with self.subTest(name="Missing expected main ion."):
+      self.assertRaises(
+          ValueError,
+          core_profiles.plasma_composition_from_IMAS,
+          core_profiles_in,
+          None,
+          ["H"],
+          None,
+      )
+    with self.subTest(name="Invalid ion name."):
+      self.assertRaises(
+          KeyError,
+          core_profiles.plasma_composition_from_IMAS,
+          core_profiles_in,
+          None,
+          None,
+          ["He"],
+      )
+    with self.subTest(name="Test config is properly built."):
+      plasma_composition_data = core_profiles.plasma_composition_from_IMAS(
+          core_profiles_in,
+          t_initial=None,
+          main_ions_symbols=["D", "T"],
+          expected_impurities=["Ne"],
+      )
+      config["plasma_composition"] = plasma_composition_data
+      config["plasma_composition"]["impurity"]["impurity_mode"] = "n_e_ratios"
+      torax_config = model_config.ToraxConfig.from_dict(config)
+
+      Ne_impurity = torax_config.plasma_composition.impurity.species["Ne"]
+      self.assertIsNotNone(Ne_impurity)
+      np.testing.assert_equal(
+          torax_config.plasma_composition.get_main_ion_names(), ("D", "T")
+      )
+      np.testing.assert_equal(
+          torax_config.plasma_composition.get_impurity_names(), ("Ne",)
+      )
+      np.testing.assert_allclose(
+          torax_config.plasma_composition.impurity.species["Ne"].get_value(0.0),
+          0.01,
+      )
+      np.testing.assert_allclose(
+          torax_config.plasma_composition.main_ion["D"].get_value(0.0), 0.5
+      )
+
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
Followup of #1486. 
Adds function to map plasma_composition data from core_profiles IDS, 
Also creates a global function which writes everything useful as TORAX input from core_profiles IDS. 

Always map Z_eff and all impurity fractions as ne ratios. 
Intended use: When dumped into a config object, manually set the impurity mode between n_e_ratios and n_e_ratios_Z_eff. If set to n_e_ratios_Z_eff, should also override one impurity ratio to None. 