### PR TITLE
feat: Add phased time step calculator for multi-window simulations

### DIFF
--- a/torax/_src/time_step_calculator/phased_time_step_calculator.py
+++ b/torax/_src/time_step_calculator/phased_time_step_calculator.py
@@ -1,0 +1,147 @@
+# Copyright 2024 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The PhasedTimeStepCalculator class.
+
+Steps through time using different fixed time steps for different time windows.
+
+Example:
+  For a simulation from 0.5s to 15.0s with different time steps for different
+  phases (as described in issue #1663):
+  
+  ```python
+  from torax._src.config import numerics
+  from torax._src.time_step_calculator import pydantic_model
+  
+  config = numerics.Numerics(
+      t_initial=0.5,
+      t_final=15.0,
+      fixed_dt=0.1,  # Fallback value
+      phased_dt_windows=((0.5, 3.0), (3.0, 13.0), (13.0, 15.0)),
+      phased_dt_values=(0.2, 0.02, 0.1),
+      time_step_calculator=pydantic_model.TimeStepCalculator(
+          calculator_type=pydantic_model.TimeStepCalculatorType.PHASED
+      )
+  )
+  ```
+  
+  This configuration will use:
+  - dt=0.2 for t ∈ [0.5, 3.0)
+  - dt=0.02 for t ∈ [3.0, 13.0)
+  - dt=0.1 for t ∈ [13.0, 15.0]
+"""
+
+import jax
+from jax import numpy as jnp
+from torax._src import state as state_module
+from torax._src.config import runtime_params_slice
+from torax._src.geometry import geometry
+from torax._src.time_step_calculator import time_step_calculator
+
+
+class PhasedTimeStepCalculator(time_step_calculator.TimeStepCalculator):
+  """TimeStepCalculator based on time-windowed fixed time steps.
+  
+  This calculator allows different fixed time steps to be used in different
+  phases of a simulation. Time windows must be contiguous and non-overlapping,
+  as validated in the Numerics configuration.
+  
+  If the current time falls outside all defined windows, the calculator falls
+  back to using numerics.fixed_dt.
+  
+  The last window includes its endpoint to properly handle the final simulation
+  time (t_final).
+  """
+
+  def _next_dt(
+      self,
+      runtime_params: runtime_params_slice.RuntimeParams,
+      geo: geometry.Geometry,
+      core_profiles: state_module.CoreProfiles,
+      core_transport: state_module.CoreTransport,
+  ) -> jax.Array:
+    """Returns the time step duration for the current time.
+    
+    Args:
+      runtime_params: Runtime parameters including numerics configuration with
+        phased_dt_windows and phased_dt_values.
+      geo: Geometry (unused, required by interface).
+      core_profiles: Core profiles containing current simulation time.
+      core_transport: Core transport (unused, required by interface).
+      
+    Returns:
+      Time step duration as a JAX array scalar.
+    """
+    current_time = core_profiles.t
+
+    # Get the time windows and corresponding dt values
+    time_windows = runtime_params.numerics.phased_dt_windows
+    dt_values = runtime_params.numerics.phased_dt_values
+
+    # Default to fixed_dt if no phased configuration is provided
+    if time_windows is None or dt_values is None:
+      return jnp.array(runtime_params.numerics.fixed_dt)
+
+    # Convert to JAX arrays for vectorized operations
+    # This approach is JAX-compatible and handles all windows simultaneously
+    starts = jnp.array([w[0] for w in time_windows])
+    ends = jnp.array([w[1] for w in time_windows])
+    dt_array = jnp.array(dt_values)
+    
+    # Find which window contains current_time
+    # For the last window, include the endpoint (<=) to properly handle t_final
+    num_windows = len(time_windows)
+    is_last_window = jnp.arange(num_windows) == (num_windows - 1)
+    
+    # Check if current_time is in each window
+    # Last window: [start, end], other windows: [start, end)
+    in_windows = jnp.where(
+        is_last_window,
+        (current_time >= starts) & (current_time <= ends),
+        (current_time >= starts) & (current_time < ends)
+    )
+    
+    # Get the index of the matching window
+    # argmax returns the index of first True value (or 0 if all False)
+    has_match = jnp.any(in_windows)
+    window_idx = jnp.argmax(in_windows)
+    
+    # Select the appropriate dt value
+    # If a window matches, use its dt; otherwise use fixed_dt as fallback
+    dt = jnp.where(
+        has_match,
+        dt_array[window_idx],
+        runtime_params.numerics.fixed_dt
+    )
+    
+    return dt
+
+  def __eq__(self, other) -> bool:
+    """Check equality based on type.
+    
+    Args:
+      other: Object to compare with.
+      
+    Returns:
+      True if other is also a PhasedTimeStepCalculator.
+    """
+    return isinstance(other, type(self))
+
+  def __hash__(self) -> int:
+    """Hash based on type.
+    
+    Returns:
+      Hash value for this calculator type.
+    """
+    return hash(type(self))

--- a/torax/_src/time_step_calculator/pydantic_model.py
+++ b/torax/_src/time_step_calculator/pydantic_model.py
@@ -19,6 +19,7 @@ from typing import Annotated
 
 from torax._src.time_step_calculator import chi_time_step_calculator
 from torax._src.time_step_calculator import fixed_time_step_calculator
+from torax._src.time_step_calculator import phased_time_step_calculator
 from torax._src.time_step_calculator import runtime_params
 from torax._src.time_step_calculator import time_step_calculator
 from torax._src.torax_pydantic import torax_pydantic
@@ -30,6 +31,7 @@ class TimeStepCalculatorType(enum.Enum):
 
   CHI = 'chi'
   FIXED = 'fixed'
+  PHASED = 'phased'
 
 
 class TimeStepCalculator(torax_pydantic.BaseModelFrozen):
@@ -56,3 +58,5 @@ class TimeStepCalculator(torax_pydantic.BaseModelFrozen):
         return chi_time_step_calculator.ChiTimeStepCalculator()
       case TimeStepCalculatorType.FIXED:
         return fixed_time_step_calculator.FixedTimeStepCalculator()
+      case TimeStepCalculatorType.PHASED:
+        return phased_time_step_calculator.PhasedTimeStepCalculator()

--- a/torax/_src/time_step_calculator/tests/test_phased_time_step_calculator.py
+++ b/torax/_src/time_step_calculator/tests/test_phased_time_step_calculator.py
@@ -1,0 +1,130 @@
+# Copyright 2024 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for PhasedTimeStepCalculator."""
+
+import unittest
+from unittest import mock
+import jax.numpy as jnp
+from torax._src import state as state_module
+from torax._src.config import numerics as numerics_lib
+from torax._src.config import runtime_params_slice
+from torax._src.time_step_calculator import phased_time_step_calculator
+
+
+class TestPhasedTimeStepCalculator(unittest.TestCase):
+  """Test the PhasedTimeStepCalculator."""
+
+  def setUp(self):
+    self.calculator = phased_time_step_calculator.PhasedTimeStepCalculator()
+
+    # Mock objects for testing
+    self.geo = mock.MagicMock()
+    self.core_transport = mock.MagicMock()
+
+  def test_phased_dt_calculation(self):
+    """Test that correct dt is returned based on current time."""
+    # Set up phased time windows
+    phased_dt_windows = ((0.5, 3.0), (3.0, 13.0), (13.0, 15.0))
+    phased_dt_values = (0.2, 0.02, 0.1)
+
+    numerics = numerics_lib.Numerics(
+        t_initial=0.5,
+        t_final=15.0,
+        fixed_dt=1e-2,
+        phased_dt_windows=phased_dt_windows,
+        phased_dt_values=phased_dt_values,
+    )
+
+    # Test different time points
+    test_cases = [
+        (1.0, 0.2),   # First window: 0.5s to 3.0s, dt=0.2
+        (5.0, 0.02),  # Second window: 3.0s to 13.0s, dt=0.02
+        (14.0, 0.1),  # Third window: 13.0s to 15.0s, dt=0.1
+    ]
+
+    for current_time, expected_dt in test_cases:
+      with self.subTest(time=current_time):
+        # Create runtime params
+        runtime_params = runtime_params_slice.RuntimeParams(
+            numerics=numerics.build_runtime_params(current_time),
+            transport=mock.MagicMock(),
+            solver=mock.MagicMock(),
+            sources={},
+            plasma_composition=mock.MagicMock(),
+            profile_conditions=mock.MagicMock(),
+            neoclassical=mock.MagicMock(),
+            pedestal=mock.MagicMock(),
+            mhd=mock.MagicMock(),
+            time_step_calculator=mock.MagicMock(),
+        )
+
+        # Create core profiles with specific time
+        core_profiles = mock.MagicMock()
+        core_profiles.t = current_time
+
+        # Calculate dt
+        dt = self.calculator._next_dt(
+            runtime_params=runtime_params,
+            geo=self.geo,
+            core_profiles=core_profiles,
+            core_transport=self.core_transport,
+        )
+
+        self.assertAlmostEqual(float(dt), expected_dt)
+
+  def test_fallback_to_fixed_dt_when_no_phased_config(self):
+    """Test fallback to fixed_dt when no phased configuration is provided."""
+    numerics = numerics_lib.Numerics(
+        fixed_dt=0.05,
+        phased_dt_windows=None,
+        phased_dt_values=None,
+    )
+
+    runtime_params = runtime_params_slice.RuntimeParams(
+        numerics=numerics.build_runtime_params(1.0),
+        transport=mock.MagicMock(),
+        solver=mock.MagicMock(),
+        sources={},
+        plasma_composition=mock.MagicMock(),
+        profile_conditions=mock.MagicMock(),
+        neoclassical=mock.MagicMock(),
+        pedestal=mock.MagicMock(),
+        mhd=mock.MagicMock(),
+        time_step_calculator=mock.MagicMock(),
+    )
+
+    core_profiles = mock.MagicMock()
+    core_profiles.t = 1.0
+
+    dt = self.calculator._next_dt(
+        runtime_params=runtime_params,
+        geo=self.geo,
+        core_profiles=core_profiles,
+        core_transport=self.core_transport,
+    )
+
+    self.assertAlmostEqual(float(dt), 0.05)
+
+  def test_equality_and_hash(self):
+    """Test equality and hash methods."""
+    calc1 = phased_time_step_calculator.PhasedTimeStepCalculator()
+    calc2 = phased_time_step_calculator.PhasedTimeStepCalculator()
+
+    self.assertEqual(calc1, calc2)
+    self.assertEqual(hash(calc1), hash(calc2))
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Implements support for multiple fixed time steps across different simulation phases, addressing issue #1663.

Changes:
- Add PhasedTimeStepCalculator class for time-windowed fixed dt
- Extend Numerics config with phased_dt_windows and phased_dt_values
- Add PHASED calculator type to TimeStepCalculatorType enum
- Implement JAX-compatible window selection logic
- Add comprehensive unit tests for phased time stepping
- Handle edge cases at window boundaries and endpoints

The implementation allows users to specify different fixed_dt values for different time windows, enabling more efficient long simulations with varying temporal resolution needs.

Fixes #1663
<img width="1920" height="1080" alt="test_result" src="https://github.com/user-attachments/assets/3299ad21-8911-481a-8da9-b99b0fea62dd" />