### PR TITLE
fix(geometry): add validation for negative radii in build_circular_geometry

### DIFF
--- a/torax/_src/geometry/circular_geometry.py
+++ b/torax/_src/geometry/circular_geometry.py
@@ -87,6 +87,10 @@ def build_circular_geometry(
   Returns:
     A Geometry instance.
   """
+  if R_major <= 0:
+    raise ValueError(f"R_major must be positive, got {R_major}")
+  if a_minor <= 0:
+    raise ValueError(f"a_minor must be positive, got {a_minor}")
   # circular geometry assumption of r/a_minor = rho_norm, the normalized
   # toroidal flux coordinate.
   # Define mesh (Slab Uniform 1D with Jacobian = 1)

--- a/torax/_src/geometry/tests/circular_geometry_test.py
+++ b/torax/_src/geometry/tests/circular_geometry_test.py
@@ -63,7 +63,29 @@ class CircularGeometryTest(absltest.TestCase):
     )
     # Make sure you can call the function with geo as an arg.
     foo(geo)
+  def test_build_circular_geometry_negative_radius_raises(self):
+    """Checks that negative radii raise a ValueError."""
+    # Test negative major radius
+    with self.assertRaisesRegex(ValueError, "R_major must be positive"):
+      circular_geometry.build_circular_geometry(
+          n_rho=10,
+          elongation_LCFS=1.0,
+          R_major=-5.0,
+          a_minor=1.0,
+          B_0=1.0,
+          hires_factor=1
+      )
 
+    # Test negative minor radius
+    with self.assertRaisesRegex(ValueError, "a_minor must be positive"):
+      circular_geometry.build_circular_geometry(
+          n_rho=10,
+          elongation_LCFS=1.0,
+          R_major=5.0,
+          a_minor=-1.0,
+          B_0=1.0,
+          hires_factor=1
+      )
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
## Summary
This PR adds input validation to the `build_circular_geometry` function to strictly enforce positive values for `R_major` and `a_minor`.

## Context / Problem
Previously, the builder accepted negative or zero radii. These invalid physical parameters would propagate into the physics kernel, causing silent failures or cryptic JAX compilation errors (e.g., `NaN`s in downstream calculations) that were difficult to debug.

## Changes
- **Source:** Added a guard clause in `torax/_src/geometry/circular_geometry.py` to raise a `ValueError` immediately if `R_major <= 0` or `a_minor <= 0`.
- **Tests:** Added a new test case `test_build_circular_geometry_negative_radius_raises` in `circular_geometry_test.py` to verify that both invalid major and minor radii are caught correctly.

## Fixes
Fixes #1790 

## Testing Plan
- [x] Verified unit tests locally: `pytest torax/_src/geometry/tests/circular_geometry_test.py` (**Passed**)
- [x] Verified full simulation suite locally (subset): `pytest torax/tests/sim_test.py` (**Passed**)