### PR TITLE
Map ICRH minority species to plasma composition

### DIFF
--- a/torax/_src/sources/tests/ion_cyclotron_source_test.py
+++ b/torax/_src/sources/tests/ion_cyclotron_source_test.py
@@ -112,7 +112,9 @@ class IonCyclotronSourceTest(test_lib.SourceTestCase):
     self.assertIsInstance(source, self._source_config_class)
     torax_pydantic.set_grid(
         source,
-        torax_pydantic.Grid1D(nx=4,),
+        torax_pydantic.Grid1D(
+            nx=4,
+        ),
     )
     runtime_params = source.build_runtime_params(t=0.0)
     self.assertIsInstance(runtime_params, runtime_params_lib.RuntimeParams)
@@ -135,7 +137,9 @@ class IonCyclotronSourceTest(test_lib.SourceTestCase):
     })
     torax_pydantic.set_grid(
         source_config,
-        torax_pydantic.Grid1D(nx=4,),
+        torax_pydantic.Grid1D(
+            nx=4,
+        ),
     )
     dynamic_params = source_config.build_runtime_params(t=0.0)
     self.assertIsInstance(dynamic_params, runtime_params_lib.RuntimeParams)
@@ -187,6 +191,64 @@ class IonCyclotronSourceTest(test_lib.SourceTestCase):
         source_models=source_models,
         neoclassical_models=neoclassical_models,
     )
+    ion_and_el = source.get_value(
+        runtime_params=runtime_params,
+        geo=geo,
+        core_profiles=core_profiles,
+        calculated_source_profiles=None,
+        conductivity=None,
+    )
+    self.assertLen(ion_and_el, 2)
+    self.assertEqual(ion_and_el[0].shape, geo.rho.shape)
+    self.assertEqual(ion_and_el[1].shape, geo.rho.shape)
+
+  def test_source_with_minority_species_from_composition(self):
+    """Tests ICRH source with minority_species reading from composition."""
+    config = default_configs.get_default_config_dict()
+    # Add He3 as an impurity in the plasma composition
+    config["plasma_composition"] = {
+        "main_ion": {"D": 0.5, "T": 0.5},
+        "impurity": {
+            "impurity_mode": "n_e_ratios",
+            "species": {"He3": 0.03},  # 3% He3 minority
+        },
+    }
+    # Configure ICRH to use minority_species instead of minority_concentration
+    config["sources"] = {
+        self._source_name: {
+            "model_path": _DUMMY_MODEL_PATH,
+            "minority_species": "He3",
+            # minority_concentration is ignored when minority_species is set
+            "minority_concentration": 0.01,  # This should be ignored
+        }
+    }
+    torax_config = model_config.ToraxConfig.from_dict(config)
+    source_models = torax_config.sources.build_models()
+    neoclassical_models = torax_config.neoclassical.build_models()
+    source = source_models.standard_sources[
+        ion_cyclotron_source.IonCyclotronSource.SOURCE_NAME
+    ]
+    self.assertIsInstance(source, source_lib.Source)
+    runtime_params = build_runtime_params.RuntimeParamsProvider.from_config(
+        torax_config
+    )(
+        t=torax_config.numerics.t_initial,
+    )
+    geo = torax_config.geometry.build_provider(torax_config.numerics.t_initial)
+    core_profiles = initialization.initial_core_profiles(
+        runtime_params=runtime_params,
+        geo=geo,
+        source_models=source_models,
+        neoclassical_models=neoclassical_models,
+    )
+    # Verify minority_species is set in runtime params
+    icrh_params = runtime_params.sources[
+        ion_cyclotron_source.IonCyclotronSource.SOURCE_NAME
+    ]
+    self.assertEqual(icrh_params.minority_species, "He3")
+    # Verify He3 is in impurity composition
+    self.assertIn("He3", runtime_params.plasma_composition.impurity_names)
+    # Run the source and check it produces valid output
     ion_and_el = source.get_value(
         runtime_params=runtime_params,
         geo=geo,


### PR DESCRIPTION
This commit addresses issue #529 by integrating ICRH minority species with the plasma composition system, ensuring physical consistency across all plasma calculations.

Changes:
- Add optional 'minority_species' parameter to IonCyclotronSourceConfig that allows specifying which species in plasma_composition to use as the ICRH minority (e.g., 'He3', 'D', 'T')
- Add _get_minority_concentration_from_composition() helper function that extracts minority concentration from plasma composition, supporting:
  * Minority species in main ions (for hydrogenic species)
  * Minority species in impurities (for helium species)
  * All three impurity modes: fractions, n_e_ratios, n_e_ratios_Z_eff
- Update icrh_model_func() to read minority concentration from plasma_composition when minority_species is set
- Maintain backward compatibility: existing configs using minority_concentration parameter continue to work

Testing:
- Add test_source_with_minority_species_from_composition() to verify new functionality with He3 minority in impurities
- All existing ICRH tests pass (backward compatibility confirmed)
- All 651 source tests pass (no regressions)

This implementation completes the first task in issue #529: "Map ICRH minority to either main-ion (if hydrogenic) or impurity (if He)"