### PR TITLE
solved IMAS plasma composition surprising behaviour

### DIFF
--- a/torax/tests/test_data/test_imas_profiles_and_geo.py
+++ b/torax/tests/test_data/test_imas_profiles_and_geo.py
@@ -33,7 +33,7 @@ imas_profiles2 = loader.load_imas_data(
 )
 imas_data1 = core_profiles.profile_conditions_from_IMAS(imas_profiles1)
 imas_data2 = core_profiles.plasma_composition_from_IMAS(
-    imas_profiles2, t_initial=0.0, expected_impurities=["He3", "Be"]
+    imas_profiles2, t_initial=0.0
 )
 
 CONFIG = copy.deepcopy(test_iterhybrid_predictor_corrector.CONFIG)


### PR DESCRIPTION
Fix IMAS plasma composition surprising behaviour (#1789)
Problem
When "He" was added as a new constants.IonProperty (alias to He4), it started being picked up as an impurity from IMAS IDS data, significantly modifying the step_flattop_bgb result (~50% different temperatures). The root cause was that the code silently ignored impurities not in constants.ION_PROPERTIES_DICT.keys(), leading to unexpected behavior when new ions were added to the dictionary.
Solution
This PR addresses the issue by:
Replacing expected_impurities with excluded_impurities: Changed the API to be more intuitive - users can now explicitly exclude impurities they don't want to process, rather than having to specify what they expect.
Adding error handling for unidentified impurities: The function now raises a clear ValueError when an ion is found in the IDS that is not in constants.ION_PROPERTIES_DICT and not in excluded_impurities. This prevents silent failures and makes it explicit when new ions are being processed.
Improved user control: Users can now explicitly control which impurities are processed using the excluded_impurities argument, preventing surprises when new ions are added to ION_PROPERTIES_DICT.
Changes Made
Modified plasma_composition_from_IMAS() in torax/_src/imas_tools/input/core_profiles.py:
Replaced expected_impurities parameter with excluded_impurities
Added validation to raise ValueError for unidentified impurities
Added logic to skip excluded impurities during processing
Updated all tests to use the new excluded_impurities API
Updated documentation strings to reflect the new behavior
Testing
Updated existing tests in torax/_src/imas_tools/input/tests/core_profiles_test.py
Added tests for the new error handling behavior
All linting checks pass
Impact
This change ensures that:
Users are explicitly notified when unidentified impurities are found
Users have control over which impurities are processed
No more silent failures that lead to unexpected simulation results
The API is more intuitive and user-friendly
Fixes #1789

