### PR TITLE
Fix imas loader test due to new imas-python tag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "pydantic>=2.10.5",
     "tqdm>=4.67.0",
     "treelib>=1.3.2",
-    "imas-python>=2.0.1",
+    "imas-python>=2.1.0",
     "typeguard==2.13.3",
 ]
 

--- a/torax/_src/imas_tools/input/tests/loader_test.py
+++ b/torax/_src/imas_tools/input/tests/loader_test.py
@@ -54,7 +54,7 @@ class IMASLoaderTest(parameterized.TestCase):
 
   def test_load_older_dd_version_without_explicit_convert_raises(self):
     directory = pathlib.Path(__file__).parent
-    with self.assertRaises(AttributeError):
+    with self.assertRaises(RuntimeError):
       loader.load_imas_data(
           "core_profiles_ddv3.nc",
           "core_profiles",


### PR DESCRIPTION
New imas-python 2.1.0 release disabled implicit conversion between major DD versions [#82](https://github.com/iterorganization/IMAS-Python/pull/82) which broke imas loader test (change from warning to RuntimeError). 

Updated imas-python requirement and fixed the test.