### PR TITLE
IMAS core_sources: Read ion particle source if electron source is not available

### DIFF
--- a/torax/_src/imas_tools/input/core_sources.py
+++ b/torax/_src/imas_tools/input/core_sources.py
@@ -18,6 +18,7 @@ import dataclasses
 from typing import Any, NamedTuple, Self
 
 from absl import logging
+from imas import ids_struct_array
 from imas import ids_structure
 from imas import ids_toplevel
 import numpy as np
@@ -63,7 +64,6 @@ _IMAS_SOURCE_ID_TO_TORAX_SOURCE_MAPPING = {
         ion_cyclotron_source.IonCyclotronSource.SOURCE_NAME,
         True,
     ),
-    # Physics-based and radiation sources
     "ohmic": _SourceMappingEntry(
         ohmic_heat_source.OhmicHeatSource.AFFECTED_CORE_PROFILES,
         ohmic_heat_source.OhmicHeatSource.SOURCE_NAME,
@@ -260,9 +260,7 @@ def _extract_source_profiles(
           profile.electrons.energy for profile in profiles_1d
       ]
     elif affected_profile == source_module.AffectedCoreProfile.NE:
-      profiles[affected_profile] = [
-          profile.electrons.particles for profile in profiles_1d
-      ]
+      profiles[affected_profile] = _get_particle_profile(profiles_1d)
     # Handling of fast ions from ICRH not taken into account yet.
     elif affected_profile == source_module.AffectedCoreProfile.FAST_IONS:
       profiles[affected_profile] = None
@@ -273,3 +271,31 @@ def _extract_source_profiles(
       affected_profiles=affected_profiles,
       profiles=profiles,
   )
+
+
+# TODO: Add option to provide full set of ion particle sources when ion
+# density transport will be possible in TORAX.
+def _get_particle_profile(
+    profiles_1d: ids_struct_array.IDSStructArray,
+) -> Sequence[Sequence[float]]:
+  """Extract particle profile from either electron or ion profiles."""
+  # Sum over all ion species to get total particle source profile.
+  if profiles_1d[0].electrons.particles.has_value:
+    particles = [profile.electrons.particles for profile in profiles_1d]
+  # If no electron particle source is defined, deduce it from the ions
+  # particle sources (assuming quasi-neutrality).
+  elif any(ion.particles is not None for ion in profiles_1d[0].ion):
+    particles = [
+        sum(
+            ion.particles * ion.element[0].z_n
+            for ion in profile.ion
+            if ion.particles is not None
+        )
+        for profile in profiles_1d
+    ]
+  else:
+    raise ValueError(
+        "Expected particle source, but none of electrons or ion particle source"
+        "is defined in the IDS."
+    )
+  return particles

--- a/torax/_src/imas_tools/input/tests/core_sources_test.py
+++ b/torax/_src/imas_tools/input/tests/core_sources_test.py
@@ -14,7 +14,9 @@
 import pathlib
 
 from absl.testing import absltest
+import imas
 import numpy as np
+import torax
 from torax._src.imas_tools.input import core_sources
 from torax._src.imas_tools.input import loader
 from torax._src.sources import source as source_module
@@ -91,7 +93,38 @@ class CoreSourcesTest(sim_test_case.SimTestCase):
     sources = core_sources.sources_from_IMAS(ids_in, None, False)
     config["sources"] |= sources
     # Checks the config can be built properly with input sources.
-    model_config.ToraxConfig.from_dict(config)
+    torax_config = model_config.ToraxConfig.from_dict(config)
+    _, imas_results = torax.run_simulation(torax_config, progress_bar=False)
+
+  def test_get_particle_profile(self):
+    """Tests that particle profile is extracted correctly.
+    
+    Test that profiles is extracted from either electrons or ions when 
+    available, and raise an error if none of them is filled. 
+    """
+    core_source = imas.IDSFactory().core_sources()
+    core_source.source.resize(3)
+    core_source.source[0].profiles_1d.resize(1)
+    core_source.source[1].profiles_1d.resize(1)
+    core_source.source[2].profiles_1d.resize(1)
+    core_source.source[0].profiles_1d[0].electrons.particles = [1.0, 2.0]
+    core_source.source[1].profiles_1d[0].ion.resize(1)
+    core_source.source[1].profiles_1d[0].ion[0].element.resize(1)
+    core_source.source[1].profiles_1d[0].ion[0].particles = [1.0, 2.0]
+    core_source.source[1].profiles_1d[0].ion[0].element[0].z_n = 1.0
+    with self.subTest(name="electrons"):
+      res = core_sources._get_particle_profile(
+          core_source.source[0].profiles_1d
+      )
+      np.testing.assert_allclose(res[0], [1.0, 2.0])
+    with self.subTest(name="ions"):
+      res = core_sources._get_particle_profile(
+          core_source.source[1].profiles_1d
+      )
+      np.testing.assert_allclose(res[0], [1.0, 2.0])
+    with self.subTest(name="Missing profiles"):
+      with self.assertRaisesRegex(ValueError, "Expected particle source"):
+        core_sources._get_particle_profile(core_source.source[2].profiles_1d)
 
 
 if __name__ == "__main__":

--- a/torax/_src/sources/ion_cyclotron_source/toric_nn.py
+++ b/torax/_src/sources/ion_cyclotron_source/toric_nn.py
@@ -576,6 +576,18 @@ class ToricNNIonCyclotronSourceConfig(base.IonCyclotronSourceConfig):
   def model_func(self) -> source.SourceProfileFunction:
     return _icrh_model_func_with_toric_nn(self.model_path)
 
+  def build_source(self) -> base.IonCyclotronSource:
+    """Builds the source, only loading the ToricNN model in MODEL_BASED mode.
+
+    When the mode is PRESCRIBED or ZERO, the model function is never called,
+    so we avoid loading the ToricNN model JSON file. This allows users who
+    don't have access to the toric_nn model file to still use the ICRH source
+    in prescribed mode.
+    """
+    if self.mode == source_runtime_params_lib.Mode.MODEL_BASED:
+      return base.IonCyclotronSource(model_func=self.model_func)
+    return base.IonCyclotronSource(model_func=None)
+
   @pydantic.model_validator(mode='after')
   def _validate_minority_species(self) -> typing_extensions.Self:
     if self.minority_species is not None and self.minority_species != 'He3':


### PR DESCRIPTION
Closes #1938. 

Waiting for #1918 to be merged to add unit test with example core_sources