### PR TITLE
Security: Input validation relies on `assert`, which can be disabled

### DIFF
--- a/torax/__init__.py
+++ b/torax/__init__.py
@@ -78,9 +78,10 @@ __all__ = [
 def set_jax_precision():
   # Default TORAX JAX precision is f64
   precision = os.getenv('JAX_PRECISION', 'f64')
-  assert precision == 'f64' or precision == 'f32', (
-      'Unknown JAX precision environment variable: %s' % precision
-  )
+  if precision not in ('f64', 'f32'):
+    raise ValueError(
+        'Unknown JAX precision environment variable: %s' % precision
+    )
   if precision == 'f64':
     jax.config.update('jax_enable_x64', True)
 


### PR DESCRIPTION
## Summary

Security: Input validation relies on `assert`, which can be disabled

## Problem

**Severity**: `Low` | **File**: `torax/__init__.py:L84`

Validation of `JAX_PRECISION` uses `assert`. Python `assert` statements are removed when running with optimization flags (`-O`), which can bypass this check and allow unexpected values to propagate. While not directly exploitable on its own, this weakens defensive validation.

## Solution

Replace `assert` with explicit runtime checks, e.g., `if precision not in {'f32','f64'}: raise ValueError(...)`.

## Changes

- `torax/__init__.py` (modified)