### PR TITLE
add HPI2-NN pellet source coupling

### DIFF
--- a/docs/hpi2nn_pellet_source.rst
+++ b/docs/hpi2nn_pellet_source.rst
@@ -1,0 +1,79 @@
+.. include:: links.rst
+
+.. _hpi2nn_pellet_source:
+
+HPI2-NN pellet source
+#####################
+
+`HPI2-NN <https://github.com/DIFFER-NL/hpi2nn>`_ is a machine-learning surrogate
+of the HPI2 pellet ablation and deposition code, developed to accelerate
+integrated modelling of pellet-fuelled tokamak discharges.
+
+.. note::
+
+   The ``hpi2nn`` package (the surrogate model and its weights) must be
+   installed to use this source. Install it as an editable package with
+   ``pip install -e <path to the hpi2nn repo>``.
+
+The particle source ``hpi2nn_pellet_source``
+(``torax/_src/sources/hpi2nn_pellet_source.py``) calls HPI2-NN to obtain the
+particle deposition profile of a pellet with the characteristics and at the
+time chosen by the user (trigger time), using the ``T_e``, ``T_i``, ``n_e`` and
+``q`` profiles from TORAX:
+
+.. code-block:: python
+
+    dne, dTe, t_abl = evaluate_hpi2nn_model(
+        radius, velocity, rho_norm, Te_eV, ne, Ti_eV, q_cell, B_0,
+        injection_point_1, injection_point_2, injection_line,
+    )
+
+The magnetic field ``B_0`` is passed as an input but is no longer used inside
+HPI2-NN in the latest version.
+
+``injection_point_1`` and ``injection_point_2`` can be used by HPI2-NN to find
+the closest matching injection line, but this feature is currently not exposed
+through the HPI2-NN pellet source (the injection line is selected directly via
+``injection_line``).
+
+See ``torax/_src/sources/hpi2nn_pellet_source.py`` for the full list of source
+attributes (pellet radius/velocity, per-trigger ``pellet_radii`` /
+``pellet_velocities``, ``trigger_times`` or ``frequency``, ``injection_line``,
+``ablation_time``, ``use_hpi2nn_ablation_time``).
+
+Ablation time and source normalisation
+=======================================
+
+The pellet source is active during the *ablation time*, which represents the
+time for the pellet to be fully ablated. Over this window the source is assumed
+constant, with the total deposited density spread over the ablation time:
+
+.. math::
+
+    S_\mathrm{pellet} = \frac{\mathrm{d}n_e}{t_\mathrm{ablation}}
+
+The ablation time is, by default, the value ``t_abl`` predicted by HPI2-NN
+(``use_hpi2nn_ablation_time = True``). Setting ``use_hpi2nn_ablation_time =
+False`` falls back to the user-provided ``ablation_time`` from the
+configuration.
+
+The pellet-aware time step calculator
+(``torax/_src/time_step_calculator/pellet_aware_time_step_calculator.py``) is
+required to ensure that the trigger times and the ablation window are resolved
+exactly. For particle conservation it sets the time step over the ablation
+window equal to the ablation time used for the source normalisation.
+
+Advice and known issues
+=======================
+
+- Our tests showed that QLKNN produced better results than TGLF-NN during the
+  post-pellet relaxation phase.
+- Using a sawtooth model can sometimes create a temperature collapse during the
+  relaxation phase. A pellet makes the pressure profile non-monotone, and a
+  sawtooth crash on such a profile can drive a low-temperature collapse.
+  If this happens, you can either slightly adjust the configuration parameters,
+  or use the ``pellet_aware_simple`` sawtooth trigger model
+  (``torax/_src/mhd/sawtooth/pellet_aware_simple_trigger.py``), which
+  suppresses sawtooth crashes for a configurable ``pellet_lockout`` window after
+  each pellet. ``pellet_lockout`` can be a scalar (applied to every pellet) or a
+  per-trigger array aligned with ``trigger_times``.

--- a/docs/user_guides.rst
+++ b/docs/user_guides.rst
@@ -26,3 +26,4 @@ input and output, the TORAX equation summary, solver details, and physics model 
    physics_models
    edge_models
    electron-cyclotron-derivation
+   hpi2nn_pellet_source

--- a/torax/_src/mhd/sawtooth/pellet_aware_simple_trigger.py
+++ b/torax/_src/mhd/sawtooth/pellet_aware_simple_trigger.py
@@ -1,0 +1,221 @@
+# Copyright 2024 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pellet-aware simple trigger model for sawteeth.
+
+Same critical-shear trigger as the simple model, but suppresses sawtooth
+crashes around pellet injection. A pellet makes the pressure profile non monotone. 
+A sawtooth crash on such a profile can cause a low temperature collapse. 
+Crashes are blocked both during the pellet ablation and for a configurable lockout 
+window after each pellet.
+"""
+
+import dataclasses
+from typing import Annotated, Literal
+
+import chex
+import jax
+from jax import numpy as jnp
+from torax._src import array_typing
+from torax._src import constants
+from torax._src import state
+from torax._src import static_dataclass
+from torax._src.config import runtime_params as runtime_params_lib
+from torax._src.geometry import geometry
+from torax._src.mhd.sawtooth import runtime_params as sawtooth_runtime_params
+from torax._src.mhd.sawtooth import trigger_base
+from torax._src.sources import hpi2nn_pellet_source
+from torax._src.torax_pydantic import torax_pydantic
+
+
+def _in_pellet_lockout(
+    pellet_params: 'hpi2nn_pellet_source.RuntimeParams',
+    lockout: array_typing.FloatScalar | array_typing.FloatVector,
+) -> jax.Array:
+  """True if the current time is within a lockout window of a pellet trigger.
+
+  If trigger times are used, 'lockout' may be a per-trigger array (same length
+  as 'trigger_times') so each pellet gets its own lockout window otherwise a scalar
+  is used for every trigger. If frequency is used, a single value is used, the
+  first element is taken if an array is provided.
+
+  Args:
+    pellet_params: Runtime params of the HPI2NN pellet source.
+    lockout: Duration(s) after each pellet trigger during which sawtooth
+      crashes are suppressed in seconds. Scalar or per trigger array [s].
+
+  Returns:
+    Boolean scalar, True inside a lockout window.
+  """
+  t = jnp.asarray(pellet_params.current_time)
+  dtype = t.dtype
+  lockout = jnp.asarray(lockout, dtype=dtype)
+  tol = jnp.asarray(1e-8, dtype=dtype)
+  if pellet_params.trigger_times is not None:
+    triggers = jnp.asarray(pellet_params.trigger_times, dtype=dtype)
+    # Per-trigger window: each trigger uses its own lockout (or the broadcast
+    # scalar). The active trigger is implicitly the one whose window contains t.
+    in_window = jnp.logical_and(t >= triggers - tol, t < triggers + lockout)
+    return jnp.any(in_window)
+  if pellet_params.frequency is not None:
+    # Frequency mode uses a single lockout; take the first element if an array
+    # was provided.
+    lockout = jnp.reshape(lockout, (-1,))[0]
+    frequency = jnp.asarray(pellet_params.frequency, dtype=dtype)
+    positive = frequency > 0.0
+    safe_frequency = jnp.where(
+        positive, frequency, jnp.asarray(1.0, dtype=dtype)
+    )
+    period = 1.0 / safe_frequency
+    t_start = jnp.asarray(pellet_params.frequency_t_start, dtype=dtype)
+    after_start = t > t_start + tol
+    phase = jnp.mod(t - t_start + tol, period)
+    return jnp.logical_and(
+        jnp.logical_and(positive, after_start), phase < lockout
+    )
+  return jnp.asarray(False)
+
+
+@dataclasses.dataclass(frozen=True, eq=False)
+class PelletAwareSimpleTrigger(
+    trigger_base.TriggerModel, static_dataclass.StaticDataclass
+):
+  """Simple critical-shear trigger with pellet-injection lockout."""
+
+  def __call__(
+      self,
+      runtime_params: runtime_params_lib.RuntimeParams,
+      geo: geometry.Geometry,
+      core_profiles: state.CoreProfiles,
+  ) -> tuple[array_typing.BoolScalar, array_typing.FloatScalar]:
+    """Checks the critical shear condition, then applies the pellet lockout.
+
+    Args:
+      runtime_params: Runtime parameters.
+      geo: Geometry object.
+      core_profiles: Core plasma profiles.
+
+    Returns:
+      tuple of (True if sawtooth crash is triggered, False otherwise,
+        radius of q=1 surface (set to 0.0 if no surface exists))
+    """
+    sawtooth_params = runtime_params.mhd.sawtooth
+    assert isinstance(sawtooth_params, sawtooth_runtime_params.RuntimeParams)
+    assert isinstance(sawtooth_params.trigger_params, RuntimeParams)
+    minimum_radius = sawtooth_params.trigger_params.minimum_radius
+    s_critical = sawtooth_params.trigger_params.s_critical
+
+    q_face = core_profiles.q_face
+    s_face = core_profiles.s_face
+    rho_face_norm = geo.rho_face_norm
+    eps = constants.CONSTANTS.eps
+
+    # Find the rightmost location where q crosses 1.0.
+    # Allows for non-monotonic q profiles.
+    q1 = q_face[:-1]
+    q2 = q_face[1:]
+    rho_norm1 = rho_face_norm[:-1]
+    rho_norm2 = rho_face_norm[1:]
+    # Handle division by zero if q1 == q2
+    dq = jnp.where(jnp.abs(q2 - q1) > eps, q2 - q1, eps)
+    # Calculate value of rho for q=1 by linearization of the q-profile
+    # in the interval. If the calculated rho is within the interval, then the
+    # q=1 surface exists for that interval.
+    potential_rho_norm_q1 = (
+        rho_norm1 + (rho_norm2 - rho_norm1) * (1.0 - q1) / dq
+    )
+    valid_interval_mask = jnp.logical_and(
+        potential_rho_norm_q1 >= rho_norm1, potential_rho_norm_q1 <= rho_norm2
+    )
+
+    # Mask out intervals where there isn't actually a crossing.
+    valid_rho_norm_q1 = jnp.where(
+        valid_interval_mask, potential_rho_norm_q1, 0.0
+    )
+
+    rho_norm_q1 = jnp.max(valid_rho_norm_q1)
+    s_at_q1 = jnp.interp(rho_norm_q1, rho_face_norm, s_face)
+
+    rho_norm_above_minimum = rho_norm_q1 > minimum_radius
+    s_above_critical = s_at_q1 > s_critical
+    trigger = jnp.logical_and(rho_norm_above_minimum, s_above_critical)
+
+    # Suppress sawtooth crashes around pellet injection. Crashes are blocked
+    # both during the ablation and for a configurable lockout window after each
+    # pellet.
+    pellet_params = runtime_params.sources.get(
+        hpi2nn_pellet_source.HPI2NNPelletSource.SOURCE_NAME
+    )
+    if pellet_params is not None and hasattr(pellet_params, 'current_time'):
+      pellet_active, _ = hpi2nn_pellet_source.is_pellet_active(pellet_params)
+      lockout = sawtooth_params.trigger_params.pellet_lockout
+      in_lockout = _in_pellet_lockout(pellet_params, lockout)
+      suppress = jnp.logical_or(pellet_active, in_lockout)
+      trigger = jnp.logical_and(trigger, jnp.logical_not(suppress))
+
+    return (
+        trigger,
+        rho_norm_q1,
+    )
+
+
+@jax.tree_util.register_dataclass
+@dataclasses.dataclass(frozen=True)
+class RuntimeParams(sawtooth_runtime_params.TriggerRuntimeParams):
+  """Runtime params for pellet-aware simple trigger model.
+
+  Attributes:
+    s_critical: Critical shear value at q=1 for sawtooth triggering.
+    pellet_lockout: Duration after each pellet trigger during which sawtooth
+      crashes are suppressed [s]. Scalar (applied to all triggers) or a
+      per-trigger array aligned with trigger_times.
+  """
+
+  s_critical: array_typing.FloatScalar
+  pellet_lockout: array_typing.FloatScalar | tuple[float, ...]
+
+
+class PelletAwareSimpleTriggerConfig(trigger_base.TriggerConfig):
+  """Pydantic model for pellet-aware simple trigger configuration.
+
+  Attributes:
+    s_critical: Critical shear value.
+    pellet_lockout: Duration after each pellet trigger during which sawtooth
+      crashes are suppressed [s]. A scalar applies to all pellets. A list
+      gives a per-trigger value aligned with trigger_times (frequency mode uses
+      the first element). Default 0.0 disables the lockout (only the ablation
+      window itself suppresses crashes).
+  """
+
+  s_critical: torax_pydantic.TimeVaryingScalar = (
+      torax_pydantic.ValidatedDefault(0.1)
+  )
+  pellet_lockout: float | tuple[float, ...] = 0.0
+  model_name: Annotated[
+      Literal['pellet_aware_simple'], torax_pydantic.JAX_STATIC
+  ] = 'pellet_aware_simple'
+
+  def build_runtime_params(
+      self,
+      t: chex.Numeric,
+  ) -> RuntimeParams:
+    base_kwargs = dataclasses.asdict(super().build_runtime_params(t))
+    return RuntimeParams(
+        **base_kwargs,
+        s_critical=self.s_critical.get_value(t),
+        pellet_lockout=self.pellet_lockout,
+    )
+
+  def build_trigger_model(self) -> PelletAwareSimpleTrigger:
+    return PelletAwareSimpleTrigger()

--- a/torax/_src/mhd/sawtooth/pydantic_model.py
+++ b/torax/_src/mhd/sawtooth/pydantic_model.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 """Pydantic model for sawtooth configuration."""
+from typing import Annotated, Union
 import chex
 import pydantic
+from torax._src.mhd.sawtooth import pellet_aware_simple_trigger
 from torax._src.mhd.sawtooth import runtime_params as sawtooth_runtime_params
 from torax._src.mhd.sawtooth import sawtooth_models
 from torax._src.mhd.sawtooth import simple_redistribution
@@ -31,9 +33,16 @@ class SawtoothConfig(torax_pydantic.BaseModelFrozen):
     crash_step_duration: Sawteeth crash period for extra timestep generated.
   """
 
-  trigger_model: simple_trigger.SimpleTriggerConfig = pydantic.Field(
-      discriminator='model_name'
-  )
+  trigger_model: Annotated[
+      Union[
+          simple_trigger.SimpleTriggerConfig,
+          pellet_aware_simple_trigger.PelletAwareSimpleTriggerConfig,
+      ],
+      pydantic.Field(
+          discriminator='model_name',
+          default_factory=simple_trigger.SimpleTriggerConfig,
+      ),
+  ]
 
   redistribution_model: simple_redistribution.SimpleRedistributionConfig = (
       pydantic.Field(discriminator='model_name')

--- a/torax/_src/output_tools/post_processing.py
+++ b/torax/_src/output_tools/post_processing.py
@@ -195,6 +195,7 @@ class PostProcessedOutputs:
     f_bootstrap: Bootstrap current fraction of the total current [dimensionless]
     S_gas_puff: Integrated gas puff source [s^-1]
     S_pellet: Integrated pellet source [s^-1]
+    S_pellet_hpi2nn: Integrated HPI2NN pellet source [s^-1]
     S_generic_particle: Integrated generic particle source [s^-1]
     S_total: Total integrated particle sources [s^-1]
     beta_tor: Volume-averaged toroidal plasma beta (thermal) [dimensionless]
@@ -311,6 +312,7 @@ class PostProcessedOutputs:
   f_bootstrap: array_typing.FloatScalar
   S_gas_puff: array_typing.FloatScalar
   S_pellet: array_typing.FloatScalar
+  S_pellet_hpi2nn: array_typing.FloatScalar
   S_generic_particle: array_typing.FloatScalar
   beta_tor: array_typing.FloatScalar
   beta_pol: array_typing.FloatScalar
@@ -424,6 +426,7 @@ class PostProcessedOutputs:
         f_bootstrap=jnp.array(0.0, dtype=jax_utils.get_dtype()),
         S_gas_puff=jnp.array(0.0, dtype=jax_utils.get_dtype()),
         S_pellet=jnp.array(0.0, dtype=jax_utils.get_dtype()),
+        S_pellet_hpi2nn=jnp.array(0.0, dtype=jax_utils.get_dtype()),
         S_generic_particle=jnp.array(0.0, dtype=jax_utils.get_dtype()),
         beta_tor=jnp.array(0.0, dtype=jax_utils.get_dtype()),
         beta_pol=jnp.array(0.0, dtype=jax_utils.get_dtype()),
@@ -474,6 +477,7 @@ CURRENT_SOURCE_TRANSFORMATIONS = {
 PARTICLE_SOURCE_TRANSFORMATIONS = {
     'gas_puff': 'S_gas_puff',
     'pellet': 'S_pellet',
+    'hpi2nn_pellet_source': 'S_pellet_hpi2nn',
     'generic_particle': 'S_generic_particle',
 }
 

--- a/torax/_src/sources/hpi2nn_pellet_source.py
+++ b/torax/_src/sources/hpi2nn_pellet_source.py
@@ -1,0 +1,408 @@
+# Copyright 2024 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""HPI2NN pellet source for the n_e equation. 
+   Returns the total deposit profile from HPI2NN as a step function in time, 
+   active during the ablation window.
+
+IMPORTANT: The pellet_aware time step calculator is needed to use this source.
+           The 'hpi2nn' package must be installed (pip install -e <hpi2nn repo>) 
+"""
+import dataclasses
+from typing import Annotated, ClassVar, Literal
+import chex
+import jax
+import jax.numpy as jnp
+import pydantic
+from torax._src import array_typing
+from torax._src import state
+from torax._src.config import runtime_params as runtime_params_lib
+from torax._src.geometry import geometry
+from torax._src.neoclassical.conductivity import base as conductivity_base
+from torax._src.sources import base
+from torax._src.sources import runtime_params as sources_runtime_params_lib
+from torax._src.sources import source
+from torax._src.sources import source_profiles
+from torax._src.torax_pydantic import torax_pydantic
+
+AllowedMachines = Literal['WEST', 'ITER', 'AUG']
+AllowedInjectionLines = Literal[
+  'WEST_upHFS',
+  'WEST_midHFS',
+  'WEST_lowHFS',
+  'WEST_LFS',
+  'ITER_upHFS',
+  'AUG_upHFS'
+]
+
+# Default value for the model function to be used for the pellet source
+# source. This is also used as an identifier for the model function in
+# the default source config for Pydantic to "discriminate" against.
+DEFAULT_MODEL_FUNCTION_NAME: str = 'hpi2_nn'
+
+#Get evaluate_model from HPI2NN to calculate dne and dTe
+#hpi2nn is installed as an editable package (pip install -e), see its README.
+def evaluate_hpi2nn_model(*args):
+  from hpi2nn.src_hpi2nn.models.JAX_HPI2NN import evaluate_model  # pylint: disable=import-outside-toplevel
+
+  return evaluate_model(*args)
+
+# The whole ablation is one time step landing exactly on the trigger. The
+# pellet-aware time-step calculator sets dt = ablation window, whether that
+# window comes from the config ablation_time or the HPI2NN t_abl. The source
+# is therefore active only at the trigger instant (within tol).
+
+# If trigger times are used, check whether the current time is at a trigger
+# instant and return the index of that trigger (if any).
+def is_active_for_trigger_times(
+    t: jax.Array,
+    trigger_times: tuple[float, ...],
+) -> tuple[jax.Array, jax.Array]:
+  tol = jnp.asarray(1e-8, dtype=t.dtype)
+  triggers = jnp.asarray(trigger_times, dtype=t.dtype)
+  at_trigger = jnp.abs(t - triggers) <= tol
+  active = jnp.any(at_trigger)
+  index = jnp.where(active, jnp.argmax(at_trigger), -1)
+  return active, jnp.asarray(index, dtype=jnp.int32)
+
+# If frequency is used, check whether the current time is at a periodic pellet
+# instant (phase measured from t_start).
+def is_active_for_frequency(
+    t: jax.Array,
+    frequency: array_typing.FloatScalar,
+    frequency_t_start: array_typing.FloatScalar,
+) -> tuple[jax.Array, jax.Array]:
+  frequency = jnp.asarray(frequency, dtype=t.dtype)
+  positive_frequency = frequency > 0.0
+  safe_frequency = jnp.where(
+      positive_frequency, frequency, jnp.asarray(1.0, dtype=t.dtype)
+  )
+  period = 1.0 / safe_frequency
+  tol = jnp.asarray(1e-8, dtype=t.dtype)
+  t_start = jnp.asarray(frequency_t_start, dtype=t.dtype)
+  # Phase is measured from t_start, no pellet fires at or before t_start.
+  after_start = t > t_start + tol
+  phase = jnp.mod(t - t_start + tol, period)
+  # Float rounding can leave phase just below period instead of wrapping to 0
+  # at a pellet time
+  phase = jnp.where(
+      period - phase < tol, jnp.asarray(0.0, dtype=t.dtype), phase
+  )
+  at_trigger = jnp.logical_and(
+      jnp.logical_and(positive_frequency, after_start),
+      phase <= tol,
+  )
+  return at_trigger, jnp.asarray(-1, dtype=jnp.int32)
+
+# Call the right function to check if the pellet source should be active.
+def is_pellet_active(source_params: 'RuntimeParams') -> tuple[jax.Array, jax.Array]:
+  t = jnp.asarray(source_params.current_time)
+  if source_params.trigger_times is not None:
+    return is_active_for_trigger_times(
+        t=t,
+        trigger_times=source_params.trigger_times,
+    )
+  if source_params.frequency is not None:
+    return is_active_for_frequency(
+        t=t,
+        frequency=source_params.frequency,
+        frequency_t_start=source_params.frequency_t_start,
+    )
+  return jnp.asarray(False), jnp.asarray(-1, dtype=jnp.int32)
+
+
+# pylint: disable=invalid-name
+# Runs the HPI2NN model and returns the total deposit profile dne [m^-3] and the
+# model-predicted ablation time t_abl [s]. The ablation time is the time duration 
+# for which the pellet is considered active after being triggered.
+def _run_hpi2nn_model(
+    source_params: 'RuntimeParams',
+    geo: geometry.Geometry,
+    core_profiles: state.CoreProfiles,
+    index_active_trigger: jax.Array,
+) -> tuple[jax.Array, jax.Array]:
+  Te_eV = core_profiles.T_e.value * 1e3
+  Ti_eV = core_profiles.T_i.value * 1e3
+  q_cell = geometry.face_to_cell(core_profiles.q_face)
+  rho_norm = geo.rho_norm
+
+  if (
+      source_params.pellet_radii is not None
+      and source_params.pellet_velocities is not None
+  ):
+    safe_index = jnp.maximum(index_active_trigger, 0)
+    pellet_radius = jnp.asarray(source_params.pellet_radii)[safe_index]
+    pellet_velocity = jnp.asarray(source_params.pellet_velocities)[safe_index]
+  else:
+    pellet_radius = source_params.pellet_radius
+    pellet_velocity = source_params.pellet_velocity
+
+  dne, dTe, t_abl = evaluate_hpi2nn_model(
+      pellet_radius, pellet_velocity, rho_norm, Te_eV,
+      core_profiles.n_e.value, Ti_eV, q_cell, geo.B_0,
+      source_params.injection_point_1, source_params.injection_point_2,
+      source_params.injection_line,
+  )
+  return jnp.asarray(dne), t_abl
+
+
+# Ablation step calculator for the pellet_aware_time_step_calculator when
+# use_hpi2nn_ablation_time is True. Returns (at_trigger, t_abl). The model runs
+# only at the trigger instant (jax.lax.cond), otherwise the config ablation_time
+# is returned as a fallback.
+def ablation_step(
+    source_params: 'RuntimeParams',
+    geo: geometry.Geometry,
+    core_profiles: state.CoreProfiles,
+) -> tuple[jax.Array, jax.Array]:
+  at_trigger, index = is_pellet_active(source_params)
+
+  def get_hpi2nn_ablation_time(_):
+    _dne, t_abl = _run_hpi2nn_model(source_params, geo, core_profiles, index)
+    return jnp.asarray(t_abl)
+
+  def fallback(_):
+    return jnp.asarray(source_params.ablation_time)
+
+  return at_trigger, jax.lax.cond(
+      at_trigger, get_hpi2nn_ablation_time, fallback, 0.0
+  )
+
+
+# The source profile is a step function in time, when active it is considered
+# constant over the ablation window. HPI2NN returns dne as total deposits so
+# they are divided by the ablation time to get the source rate.
+def calc_pellet_source(
+    runtime_params: runtime_params_lib.RuntimeParams,
+    geo: geometry.Geometry,
+    source_name: str,
+    core_profiles: state.CoreProfiles,
+    calculated_source_profiles: source_profiles.SourceProfiles | None,
+    unused_conductivity: conductivity_base.Conductivity | None,
+) -> tuple[array_typing.FloatVectorCell, ...]:
+  """Calculates external source term for n from pellets."""
+  source_params = runtime_params.sources[source_name]
+  assert isinstance(source_params, RuntimeParams)
+  use = source_params.use_hpi2nn_ablation_time
+
+  is_active, index_active_trigger = is_pellet_active(source_params)
+
+  def active_pellet(_):
+    dne, t_abl = _run_hpi2nn_model(
+        source_params, geo, core_profiles, index_active_trigger
+    )
+    divisor = t_abl if use else source_params.ablation_time
+
+    return (dne / divisor,)
+
+  def inactive_pellet(_):
+    return (jnp.zeros_like(geo.rho_norm),)
+
+  return jax.lax.cond(is_active, active_pellet, inactive_pellet, 0.0)
+
+
+@dataclasses.dataclass(kw_only=True, frozen=True, eq=False)
+class HPI2NNPelletSource(source.Source):
+  """HPI2NN pellet source for the n_e equation."""
+
+  SOURCE_NAME: ClassVar[str] = 'hpi2nn_pellet_source'
+  AFFECTED_CORE_PROFILES: ClassVar[tuple[source.AffectedCoreProfile, ...]] = (source.AffectedCoreProfile.NE,)
+  model_func: source.SourceProfileFunction = calc_pellet_source
+
+  @property
+  def source_name(self) -> str:
+    """Returns the name of the source."""
+    return self.SOURCE_NAME
+
+  @property
+  def affected_core_profiles(self) -> tuple[source.AffectedCoreProfile, ...]:
+    """Returns the core profiles affected by this source."""
+    return self.AFFECTED_CORE_PROFILES
+
+
+@jax.tree_util.register_dataclass
+@dataclasses.dataclass(frozen=True)
+class RuntimeParams(sources_runtime_params_lib.RuntimeParams):
+  pellet_radius: array_typing.FloatScalar
+  pellet_velocity: array_typing.FloatScalar
+  injection_line: str = dataclasses.field(metadata={'static': True})
+  injection_point_1: tuple[float, float]
+  injection_point_2: tuple[float, float]
+  trigger_times: tuple[float, ...] | None
+  # Per-trigger radius and velocity (must have same length as trigger_times).
+  # If None, pellet_radius and pellet_velocity are used for all triggers.
+  pellet_radii: tuple[float, ...] | None
+  pellet_velocities: tuple[float, ...] | None
+  frequency: array_typing.FloatScalar | None
+  frequency_t_start: array_typing.FloatScalar
+  ablation_time: array_typing.FloatScalar
+  current_time: array_typing.FloatScalar
+  # When True, the ablation window is the HPI2NN-predicted t_abl instead of the
+  # config ablation_time.
+  use_hpi2nn_ablation_time: bool = dataclasses.field(metadata={'static': True})
+
+
+class HPI2NNPelletConfig(base.SourceModelBase):
+  """Configuration for the HPI2NN pellet source.
+
+  Attributes:
+    pellet_radius: Radius of the pellet in meters [m].
+    pellet_velocity: Velocity of the pellet in meters per second [m/s].
+    injection_line: Line of injection for the pellet.
+      Allowed values are 'WEST_upHFS', 'WEST_midHFS', 'WEST_lowHFS',
+      'WEST_LFS', 'ITER_upperHFS', 'AUG_upHFS'.
+    injection_point_1: First injection point (R, Z) [m].
+      Not used if injection_line is specified.
+    injection_point_2: Second injection point (R, Z) [m].
+      Not used if injection_line is specified.
+    trigger_times: A list of times to fire the pellet [s].
+      If None, the pellet is not triggered by specific times.
+    pellet_radii: A list of pellet radii corresponding to each trigger time [m].
+      Must have the same length as trigger_times. If None, pellet_radius is
+      used for all triggers.
+    pellet_velocities: A list of pellet velocities corresponding to each
+      trigger time [m/s]. Must have the same length as trigger_times. If None,
+      pellet_velocity is used for all triggers.
+    frequency: A frequency for firing the pellet [Hz].
+      If 0 or None, the pellet is not triggered by frequency.
+      If specified, the pellet is fired at regular intervals defined by the
+      frequency.
+    frequency_t_start: Reference time for frequency mode [s]. The phase is
+      measured from this time and no pellet fires at or before it. Set it to
+      t_initial to avoid a spurious first shot.
+    use_hpi2nn_ablation_time : When True (default), let hpi2nn predict the ablation time t_abl 
+      for the deposit normalization and the time-step window.
+    ablation_time: Let the user fix the ablation time [s] for all the pellets. 
+      This is used only when use_hpi2nn_ablation_time is False. 
+      Shoudn't be used in most cases.
+  """
+
+  model_name: Annotated[
+      Literal["hpi2_nn"], torax_pydantic.JAX_STATIC
+  ] = "hpi2_nn"
+
+  pellet_radius: torax_pydantic.TimeVaryingScalar=(
+      torax_pydantic.ValidatedDefault(0.001) # [m]
+  )
+  pellet_velocity: torax_pydantic.TimeVaryingScalar=(
+      torax_pydantic.ValidatedDefault(200.0) # [m/s]
+  )
+  injection_line: Annotated[
+      AllowedInjectionLines,
+      torax_pydantic.JAX_STATIC,
+  ] = 'WEST_upHFS'
+  # The injection points are not used by the model but are kept in the config
+  # because they are inputs of hpi2nn. They are not used if the injection line
+  # is specified.
+  injection_point_1: tuple[float, float]=(
+    torax_pydantic.ValidatedDefault((1.8, 0.47)) # (R, Z) in meters
+  )
+  injection_point_2: tuple[float, float]=(
+    torax_pydantic.ValidatedDefault((2.6192, -0.136)) # (R, Z) in meters
+  )
+  trigger_times: list[float] | None = None
+  # Per-trigger radius and velocity (must have same length as trigger_times).
+  # If None, pellet_radius and pellet_velocity are used for all triggers.
+  pellet_radii: list[float] | None = None
+  pellet_velocities: list[float] | None = None
+  # OR a frequency, where 0 is "never" and value can be time-dependent
+  frequency: torax_pydantic.TimeVaryingScalar | None = None
+  # Reference time for frequency mode: phase is measured from this time and no
+  # pellet fires at or before it.
+  frequency_t_start: torax_pydantic.TimeVaryingScalar=(
+      torax_pydantic.ValidatedDefault(0.0) # [s]
+  )
+  ablation_time: torax_pydantic.TimeVaryingScalar=(
+      torax_pydantic.ValidatedDefault(1e-3) # [s]
+  )
+  use_hpi2nn_ablation_time: Annotated[bool, torax_pydantic.JAX_STATIC] = True
+
+  mode: Annotated[
+      sources_runtime_params_lib.Mode, torax_pydantic.JAX_STATIC
+  ] = sources_runtime_params_lib.Mode.MODEL_BASED
+
+  @property
+  def model_func(self) -> source.SourceProfileFunction:
+    return calc_pellet_source
+
+  @pydantic.model_validator(mode='after')
+  def _validate_trigger_config(self):
+    if self.trigger_times is not None and self.frequency is not None:
+      raise ValueError(
+          'Pellet source configuration must set either trigger_times or '
+          'frequency, but not both.'
+      )
+    if self.frequency is not None and self.frequency.get_value(0.0) < 0.0:
+      raise ValueError('frequency must be non-negative.')
+    if self.frequency is not None and (
+        self.pellet_radii is not None or self.pellet_velocities is not None
+    ):
+      raise ValueError(
+          'pellet_radii and pellet_velocities are not supported with frequency '
+          'mode; use pellet_radius and pellet_velocity (scalar) instead.'
+      )
+    if self.ablation_time.get_value(0.0) <= 0.0:
+      raise ValueError('ablation_time must be strictly positive.')
+    if self.trigger_times is not None and any(t < 0.0 for t in self.trigger_times):
+      raise ValueError('trigger_times must be non-negative.')
+    if self.pellet_radii is not None and self.trigger_times is not None:
+      if len(self.pellet_radii) != len(self.trigger_times):
+        raise ValueError(
+            f'pellet_radii length ({len(self.pellet_radii)}) must match '
+            f'trigger_times length ({len(self.trigger_times)}).'
+        )
+    if self.pellet_velocities is not None and self.trigger_times is not None:
+      if len(self.pellet_velocities) != len(self.trigger_times):
+        raise ValueError(
+            f'pellet_velocities length ({len(self.pellet_velocities)}) must '
+            f'match trigger_times length ({len(self.trigger_times)}).'
+        )
+    return self
+
+  def build_runtime_params(
+      self,
+      t: chex.Numeric,
+  ) -> RuntimeParams:
+    trigger_times = (
+      tuple(self.trigger_times)
+      if self.trigger_times is not None
+      else None
+    )
+    return RuntimeParams(
+        prescribed_values=tuple(
+            [v.get_value(t) for v in self.prescribed_values]
+        ),
+        mode=self.mode,
+        is_explicit=self.is_explicit,
+        pellet_radius=self.pellet_radius.get_value(t),
+        pellet_velocity=self.pellet_velocity.get_value(t),
+        injection_line=self.injection_line,
+        injection_point_1=self.injection_point_1,
+        injection_point_2=self.injection_point_2,
+        trigger_times=trigger_times,
+        pellet_radii=tuple(self.pellet_radii) if self.pellet_radii is not None else None,
+        pellet_velocities=tuple(self.pellet_velocities) if self.pellet_velocities is not None else None,
+        frequency=(self.frequency.get_value(t) if self.frequency is not None else None),
+        frequency_t_start=self.frequency_t_start.get_value(t),
+        ablation_time=self.ablation_time.get_value(t),
+        use_hpi2nn_ablation_time=self.use_hpi2nn_ablation_time,
+        current_time=jnp.asarray(t),
+    )
+
+  def build_source(self) -> HPI2NNPelletSource:
+    return HPI2NNPelletSource(model_func=self.model_func)
+
+
+# Backward-compatible aliases expected by source registration and tests.
+PelletSource = HPI2NNPelletSource
+PelletSourceConfig = HPI2NNPelletConfig

--- a/torax/_src/sources/pydantic_model.py
+++ b/torax/_src/sources/pydantic_model.py
@@ -28,6 +28,7 @@ from torax._src.sources import gas_puff_source as gas_puff_source_lib
 from torax._src.sources import generic_current_source as generic_current_source_lib
 from torax._src.sources import generic_ion_el_heat_source as generic_ion_el_heat_source_lib
 from torax._src.sources import generic_particle_source as generic_particle_source_lib
+from torax._src.sources import hpi2nn_pellet_source as hpi2nn_pellet_source_lib
 from torax._src.sources import ohmic_heat_source as ohmic_heat_source_lib
 from torax._src.sources import pellet_source as pellet_source_lib
 from torax._src.sources import qei_source as qei_source_lib
@@ -90,6 +91,12 @@ class Sources(torax_pydantic.BaseModelFrozen):
   )
   generic_particle: (
       generic_particle_source_lib.GenericParticleSourceConfig | None
+  ) = pydantic.Field(
+      discriminator='model_name',
+      default=None,
+  )
+  hpi2nn_pellet_source: (
+      hpi2nn_pellet_source_lib.HPI2NNPelletConfig | None
   ) = pydantic.Field(
       discriminator='model_name',
       default=None,
@@ -161,6 +168,11 @@ class Sources(torax_pydantic.BaseModelFrozen):
             constructor_data[k][
                 'model_name'
             ] = pellet_source_lib.DEFAULT_MODEL_FUNCTION_NAME
+        case 'hpi2nn_pellet_source':
+          if 'model_name' not in v:
+            constructor_data[k][
+                'model_name'
+            ] = hpi2nn_pellet_source_lib.DEFAULT_MODEL_FUNCTION_NAME
         case 'fusion':
           if 'model_name' not in v:
             constructor_data[k][

--- a/torax/_src/sources/register_model.py
+++ b/torax/_src/sources/register_model.py
@@ -22,6 +22,7 @@ from torax._src.sources import gas_puff_source as gas_puff_source_lib
 from torax._src.sources import generic_current_source as generic_current_source_lib
 from torax._src.sources import generic_ion_el_heat_source as generic_ion_el_heat_source_lib
 from torax._src.sources import generic_particle_source as generic_particle_source_lib
+from torax._src.sources import hpi2nn_pellet_source as hpi2nn_pellet_source_lib
 from torax._src.sources import ohmic_heat_source as ohmic_heat_source_lib
 from torax._src.sources import pellet_source as pellet_source_lib
 from torax._src.sources import pydantic_model as sources_pydantic_model
@@ -72,6 +73,10 @@ def _validate_source_model_config(
       )
     case pellet_source_lib.PelletSource.SOURCE_NAME:
       default_model_name = pellet_source_lib.DEFAULT_MODEL_FUNCTION_NAME
+    case hpi2nn_pellet_source_lib.HPI2NNPelletSource.SOURCE_NAME:
+      default_model_name = (
+          hpi2nn_pellet_source_lib.DEFAULT_MODEL_FUNCTION_NAME
+      )
     case fusion_heat_source_lib.FusionHeatSource.SOURCE_NAME:
       default_model_name = fusion_heat_source_lib.DEFAULT_MODEL_FUNCTION_NAME
     case (

--- a/torax/_src/time_step_calculator/pellet_aware_time_step_calculator.py
+++ b/torax/_src/time_step_calculator/pellet_aware_time_step_calculator.py
@@ -1,0 +1,289 @@
+# Copyright 2024 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Time step calculator that aligns steps with pellet trigger windows."""
+
+import jax
+from jax import numpy as jnp
+from torax._src.config import runtime_params as runtime_params_lib
+from torax._src.orchestration import sim_state as sim_state_lib
+from torax._src.sources import hpi2nn_pellet_source as hpi2nn_pellet_source_lib
+from torax._src.time_step_calculator import chi_time_step_calculator
+from torax._src.time_step_calculator import fixed_time_step_calculator
+from torax._src.time_step_calculator import time_step_calculator
+
+
+class PelletAwareTimeStepCalculator(time_step_calculator.TimeStepCalculator):
+  """TimeStepCalculator that resolves pellet trigger and ablation windows.
+
+  The pellet_aware time step calculator ensures that time steps are aligned with
+  pellet trigger times and ablation windows. 
+
+  It checks the current simulation time against the pellet trigger times 
+  and ablation duration, and adjusts the time step to ensure that steps 
+  do not skip over these events. 
+  
+  Arguments:
+    base_calculator_type: The type of the base time step calculator to use for
+      non-pellet-alignment purposes. Must be 'chi' or 'fixed'.
+    trigger_tolerance: The time tolerance for determining if the current time is
+      at a pellet trigger or ablation boundary.
+    pellet_source_name: The name of the pellet source in the runtime parameters.
+    window_after_pellet: The duration of the window after a pellet trigger during
+      which the time step is adjusted. The duration of the first time step will always
+      be equal to the ablation time, the other will be equal to dt_after_pellet.
+      Not used by default.
+    dt_after_pellet: The time step to use during the window after a pellet trigger.
+      If None, the base calculator's time step is used. Not used by default.
+
+    Returns:
+      dt: Scalar time step duration.  
+  """
+
+  def __init__(
+      self,
+      base_calculator_type: str = 'chi',
+      trigger_tolerance: float = 1e-8,
+      pellet_source_name: str = 'hpi2nn_pellet_source',
+      window_after_pellet: float = 0.0,
+      dt_after_pellet: float | None = None,
+  ):
+    self._base_calculator_type = base_calculator_type
+    self._trigger_tolerance = float(trigger_tolerance)
+    self._pellet_source_name = pellet_source_name
+    self._window_after_pellet = float(window_after_pellet)
+    self._dt_after_pellet = (
+        float(dt_after_pellet) if dt_after_pellet is not None else None
+    )
+    if base_calculator_type == 'chi':
+      self._base_calculator = chi_time_step_calculator.ChiTimeStepCalculator()
+    elif base_calculator_type == 'fixed':
+      self._base_calculator = (
+          fixed_time_step_calculator.FixedTimeStepCalculator()
+      )
+    else:
+      raise ValueError(
+          'base_calculator must be "chi" or "fixed" '
+      )
+
+  def _next_dt(
+      self,
+      runtime_params: runtime_params_lib.RuntimeParams,
+      sim_state: sim_state_lib.SimState,
+  ) -> jax.Array:
+    """Returns a dt aligned with pellet trigger and ablation windows."""
+    dt_standard = self._base_calculator._next_dt(runtime_params, sim_state)
+    dt_standard = jnp.asarray(dt_standard)
+    dtype = dt_standard.dtype
+
+    t = sim_state.t
+    pellet_params = runtime_params.sources.get(self._pellet_source_name)
+    if pellet_params is None:
+      return dt_standard
+
+    trigger_times = getattr(pellet_params, 'trigger_times', None)
+    frequency = getattr(pellet_params, 'frequency', None)
+    ablation_time = getattr(pellet_params, 'ablation_time', None)
+    if ablation_time is None:
+        return dt_standard
+
+    t = jnp.asarray(t, dtype=dtype)
+    tol = jnp.asarray(self._trigger_tolerance, dtype=dtype)
+    ablation_time = jnp.asarray(ablation_time, dtype=dtype)
+    inf = jnp.asarray(jnp.inf, dtype=dtype)
+    window_after_pellet = jnp.asarray(self._window_after_pellet, dtype=dtype)
+
+    in_ablation = jnp.asarray(False)
+    ablation_remaining = inf
+    dt_trigger = inf
+    next_trigger = inf
+    dt_after_trigger = inf
+    at_trigger = jnp.asarray(False)
+    model_ablation_time = inf
+
+    use_model_ablation = bool(
+        getattr(pellet_params, 'use_hpi2nn_ablation_time', False)
+    )
+    if use_model_ablation:
+      at_trigger, model_ablation_time = hpi2nn_pellet_source_lib.ablation_step(
+          pellet_params, sim_state.geometry, sim_state.core_profiles
+      )
+      at_trigger = jnp.asarray(at_trigger)
+      model_ablation_time = jnp.asarray(model_ablation_time, dtype=dtype)
+
+    if trigger_times is not None:
+      neg_inf = jnp.asarray(-jnp.inf, dtype=dtype)
+      last_trigger = neg_inf
+
+      for trigger in trigger_times:
+        trigger = jnp.asarray(trigger, dtype=dtype)
+        is_next_trigger = trigger > t - tol
+        next_trigger = jnp.where(
+          is_next_trigger,
+          jnp.minimum(next_trigger, trigger),
+          next_trigger,
+        )
+        is_past = trigger <= t + tol
+        last_trigger = jnp.where(
+          is_past,
+          jnp.maximum(last_trigger, trigger),
+          last_trigger,
+        )
+
+      delta_to_next_trigger = next_trigger - t
+      if use_model_ablation:
+        # One step at the trigger covering the model-predicted ablation time.
+        # ablation_remaining is only read when in_ablation.
+        in_ablation = at_trigger
+        ablation_remaining = model_ablation_time
+        dt_trigger = jnp.where(
+            at_trigger, model_ablation_time, delta_to_next_trigger
+        )
+      else:
+        end = next_trigger + ablation_time
+        in_ablation = jnp.logical_and(
+          t >= next_trigger - tol,
+          t < end - tol,
+        )
+        ablation_remaining = jnp.where(
+            in_ablation,
+            end - t,
+            ablation_remaining,
+        )
+        dt_trigger = jnp.where(
+            in_ablation,
+            ablation_remaining,
+            delta_to_next_trigger,
+        )
+      if self._dt_after_pellet is not None:
+        dt_after_pellet = jnp.asarray(self._dt_after_pellet, dtype=dtype)
+        has_past_trigger = jnp.isfinite(last_trigger)
+        post_window_end = last_trigger + window_after_pellet
+        in_post_pellet = jnp.logical_and(
+            has_past_trigger,
+            jnp.logical_and(
+                jnp.logical_and(
+                    t > last_trigger + tol, jnp.logical_not(in_ablation)
+                ),
+                t < post_window_end - tol,
+            ),
+        )
+        post_remaining = post_window_end - t
+        dt_after_trigger = jnp.where(
+            in_post_pellet,
+            jnp.minimum(dt_after_pellet, post_remaining),
+            inf,
+        )
+
+
+    elif frequency is not None:
+      frequency = jnp.asarray(frequency, dtype=dtype)
+      frequency_t_start = jnp.asarray(
+          getattr(pellet_params, 'frequency_t_start', 0.0), dtype=dtype
+      )
+      positive_frequency = frequency > 0.0
+      safe_frequency = jnp.where(
+          positive_frequency, frequency, jnp.asarray(1.0, dtype=dtype)
+      )
+      period = 1.0 / safe_frequency
+      # Phase measured from frequency_t_start (consistent with the source).
+      phase = jnp.mod(t - frequency_t_start + tol, period)
+      # Float rounding can leave phase just below period instead of wrapping
+      # to 0 at a pellet time.
+      phase = jnp.where(
+          period - phase < tol, jnp.asarray(0.0, dtype=dtype), phase
+      )
+      delta_to_next_period = period - phase
+
+      after_start = t > frequency_t_start + tol
+      if use_model_ablation:
+        in_ablation = at_trigger
+        ablation_remaining = model_ablation_time
+        dt_trigger_value = jnp.where(
+            at_trigger, model_ablation_time, delta_to_next_period
+        )
+      else:
+        in_ablation = jnp.logical_and(
+            jnp.logical_and(positive_frequency, after_start),
+            phase < ablation_time - tol,
+        )
+        ablation_remaining = jnp.where(
+            in_ablation,
+            ablation_time - phase,
+            ablation_remaining,
+        )
+        dt_trigger_value = jnp.where(
+            in_ablation,
+            ablation_remaining,
+            delta_to_next_period,
+        )
+      dt_trigger = jnp.where(
+          jnp.logical_and(positive_frequency, after_start),
+          dt_trigger_value,
+          dt_trigger,
+      )
+      if self._dt_after_pellet is not None:
+        dt_after_pellet = jnp.asarray(self._dt_after_pellet, dtype=dtype)
+        in_post_pellet_freq = jnp.logical_and(
+            jnp.logical_and(positive_frequency, after_start),
+            jnp.logical_and(
+                jnp.logical_and(phase > tol, jnp.logical_not(in_ablation)),
+                phase < window_after_pellet - tol,
+            ),
+        )
+        post_remaining_freq = window_after_pellet - phase
+        dt_after_trigger = jnp.where(
+            in_post_pellet_freq,
+            jnp.minimum(dt_after_pellet, post_remaining_freq),
+            inf,
+        )
+
+    dt = jnp.minimum(dt_standard, jnp.minimum(dt_trigger, dt_after_trigger))
+    # During ablation, never split the window: even if dt_standard is smaller.
+    dt = jnp.where(in_ablation, ablation_remaining, dt)
+
+    crosses_t_final = (t < runtime_params.numerics.t_final) * (
+        t + dt > runtime_params.numerics.t_final
+    )
+    dt = jax.lax.select(
+        jnp.logical_and(
+            runtime_params.numerics.exact_t_final,
+            crosses_t_final,
+        ),
+        runtime_params.numerics.t_final - t,
+        dt,
+    )
+    return dt
+
+  def __eq__(self, other) -> bool:
+    return (
+        isinstance(other, type(self))
+        and self._base_calculator_type == other._base_calculator_type
+        and self._trigger_tolerance == other._trigger_tolerance
+        and self._pellet_source_name == other._pellet_source_name
+        and self._window_after_pellet == other._window_after_pellet
+        and self._dt_after_pellet == other._dt_after_pellet
+    )
+
+  def __hash__(self) -> int:
+    return hash(
+        (
+            type(self),
+            self._base_calculator_type,
+            self._trigger_tolerance,
+            self._pellet_source_name,
+            self._window_after_pellet,
+            self._dt_after_pellet,
+        )
+    )

--- a/torax/_src/time_step_calculator/pydantic_model.py
+++ b/torax/_src/time_step_calculator/pydantic_model.py
@@ -20,6 +20,7 @@ from typing import Annotated
 from torax._src.time_step_calculator import chi_time_step_calculator
 from torax._src.time_step_calculator import fixed_time_step_calculator
 from torax._src.time_step_calculator import from_previous_time_step_calculator
+from torax._src.time_step_calculator import pellet_aware_time_step_calculator
 from torax._src.time_step_calculator import runtime_params
 from torax._src.time_step_calculator import time_step_calculator
 from torax._src.torax_pydantic import torax_pydantic
@@ -32,7 +33,14 @@ class TimeStepCalculatorType(enum.Enum):
   CHI = 'chi'
   FIXED = 'fixed'
   FROM_PREVIOUS_DT = 'from_previous_dt'
+  PELLET_AWARE = 'pellet_aware'
 
+@enum.unique
+class BaseTimeStepCalculatorType(enum.Enum):
+  """Types of base time step calculators wrapped by pellet-aware mode."""
+
+  CHI = 'chi'
+  FIXED = 'fixed'
 
 class TimeStepCalculator(torax_pydantic.BaseModelFrozen):
   """Config for a time step calculator.
@@ -47,6 +55,13 @@ class TimeStepCalculator(torax_pydantic.BaseModelFrozen):
       TimeStepCalculatorType, torax_pydantic.JAX_STATIC
   ] = TimeStepCalculatorType.CHI
   tolerance: float = 1e-7
+  base_calculator_type: Annotated[
+      BaseTimeStepCalculatorType, torax_pydantic.JAX_STATIC
+  ] = BaseTimeStepCalculatorType.CHI
+  trigger_tolerance: float = 1e-8
+  tolerance: float = 1e-7
+  window_after_pellet: float = 0.0
+  dt_after_pellet: float | None = None  
 
   def build_runtime_params(self) -> runtime_params.RuntimeParams:
     return runtime_params.RuntimeParams(tolerance=self.tolerance)
@@ -62,4 +77,11 @@ class TimeStepCalculator(torax_pydantic.BaseModelFrozen):
       case TimeStepCalculatorType.FROM_PREVIOUS_DT:
         return (
             from_previous_time_step_calculator.FromPreviousTimeStepCalculator()
+        )
+      case TimeStepCalculatorType.PELLET_AWARE:
+        return pellet_aware_time_step_calculator.PelletAwareTimeStepCalculator(
+            base_calculator_type=self.base_calculator_type.value,
+            trigger_tolerance=self.trigger_tolerance,
+            window_after_pellet=self.window_after_pellet,
+            dt_after_pellet=self.dt_after_pellet,
         )

--- a/torax/examples/hpi2nn_pellet_basic.py
+++ b/torax/examples/hpi2nn_pellet_basic.py
@@ -1,0 +1,76 @@
+# Copyright 2024 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Self-contained example of the HPI2-NN pellet source.
+
+The purpose of this example is simply to test that the coupling between 
+torax and hpi2nn is working properly and to show a minimal configuration.
+
+Requirements:
+  - The 'hpi2nn' package must be installed (pip install -e <hpi2nn repo>), it
+    provides the surrogate model and its weights. See docs/hpi2nn_pellet_source.
+"""
+
+CONFIG = {
+    'profile_conditions': {},  # default profile conditions
+    'plasma_composition': {},  # default plasma composition
+    'numerics': {
+        't_initial': 0.0,
+        't_final': 10,
+        'fixed_dt': 0.01,
+        'min_dt': 1e-4,
+        # The density equation must be evolved for the pellet to fuel the core.
+        'evolve_density': True,
+        'evolve_ion_heat': True,
+        'evolve_electron_heat': True,
+        'evolve_current': True,
+    },
+    # Circular geometry is only for testing and prototyping (no external files).
+    'geometry': {
+        'geometry_type': 'circular',
+    },
+    'neoclassical': {
+        'bootstrap_current': {},
+    },
+    'sources': {
+        # Current source (for the psi equation).
+        'generic_current': {},
+        # Ion and electron heat sources (for the temp-ion and temp-el eqs).
+        'generic_heat': {},
+        'ei_exchange': {},
+        'ohmic': {},
+        # HPI2-NN pellet particle source (for the n_e equation).
+        'hpi2nn_pellet_source': {
+            'trigger_times': [2.0, 6.0],
+            'pellet_radius': 1.0e-3,  # [m]
+            'pellet_velocity': 100.0,  # [m/s]
+            'injection_line': 'WEST_upHFS',
+            'use_hpi2nn_ablation_time': False,
+            'ablation_time': 1e-3,  # [s]
+        },
+    },
+    'pedestal': {},
+    'transport': {
+        'model_name': 'constant',
+    },
+
+    'solver': {
+        'solver_type': 'linear',
+    },
+    # Mandatory for the HPI2-NN pellet source.
+    'time_step_calculator': {
+        'calculator_type': 'pellet_aware',
+        'base_calculator_type': 'fixed',
+    },
+}


### PR DESCRIPTION
- New particle source `hpi2nn_pellet_source` calling HPI2NN.
- New `pellet_aware_time_step_calculator` aligning steps with pellet trigger times and the ablation window.
- New sawtooth trigger `pellet_aware_simple_trigger` with a post-pellet `pellet_lockout` to avoid post-injection temperature collapse.
- Example `hpi2nn_pellet_basic.py` and documentation `hpi2nn_pellet_source.rst`.