### PR TITLE
Followup PR: Implement IMAS output core_sources mapping, add generic sources

### DIFF
--- a/torax/_src/imas_tools/output/core_sources.py
+++ b/torax/_src/imas_tools/output/core_sources.py
@@ -118,7 +118,15 @@ def core_sources_to_IMAS(
           torax_config,
           src_name,
       )
+      _fill_global_quantities(
           source_node.global_quantities[i],
+          cs_state,
+          core_profile_state,
+          ppo,
+          geo,
+          torax_config,
+          src_name,
+      )
 
   return ids
 
@@ -220,3 +228,44 @@ def _fill_profiles_1d(
     profiles_1d_slice.ion[k].element[0].a = ion_properties.A
     profiles_1d_slice.ion[k].element[0].z_n = ion_properties.Z
 
+
+def _fill_global_quantities(
+    global_quantities_slice: imas.ids_structure.IDSStructure,
+    cs_state: source_profiles.SourceProfiles,
+    core_profile_state: state_lib.CoreProfiles,
+    ppo: post_processing.PostProcessedOutputs,
+    geo: geometry_lib.Geometry,
+    torax_config: model_config.ToraxConfig,
+    src_name: str,
+) -> None:
+  """Fills integrated global quantities for a source at a single time slice."""
+  energy_el_cell = np.zeros_like(geo.rho)
+  energy_ion_cell = np.zeros_like(geo.rho)
+  particles_el_cell = np.zeros_like(geo.rho)
+  j_par_cell = np.zeros_like(geo.rho)
+
+  if src_name == "qei":
+    qei_val = cs_state.qei.qei_coef * (
+        core_profile_state.T_e.value - core_profile_state.T_i.value
+    )
+    energy_ion_cell = qei_val
+    energy_el_cell = -qei_val
+  else:
+    energy_el_cell = cs_state.T_e.get(src_name, energy_el_cell)
+    energy_ion_cell = cs_state.T_i.get(src_name, energy_ion_cell)
+    particles_el_cell = cs_state.n_e.get(src_name, particles_el_cell)
+    j_par_cell = cs_state.psi.get(src_name, j_par_cell)
+
+  power_el = math_utils.volume_integration(energy_el_cell, geo)
+  power_ion = math_utils.volume_integration(energy_ion_cell, geo)
+  particles_el_int = math_utils.volume_integration(particles_el_cell, geo)
+  # TODO(b/335204606): Clean this up once we finalize our COCOS convention.
+  # Currents sign flipped due to the difference between TORAX COCOS convention
+  # and IMAS COCOS.
+  j_curr_int = -1.0 * math_utils.area_integration(j_par_cell, geo)
+
+  global_quantities_slice.electrons.power = power_el
+  global_quantities_slice.total_ion_power = power_ion
+  global_quantities_slice.power = power_el + power_ion
+  global_quantities_slice.electrons.particles = particles_el_int
+  global_quantities_slice.current_parallel = j_curr_int

--- a/torax/_src/imas_tools/output/core_sources.py
+++ b/torax/_src/imas_tools/output/core_sources.py
@@ -1,0 +1,154 @@
+# Copyright 2026 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Functions to save IMAS core_sources IDSs from TORAX."""
+
+from collections.abc import Sequence
+import datetime
+
+import imas
+from imas import ids_toplevel
+import numpy as np
+from torax._src import array_typing
+from torax._src import constants
+from torax._src import math_utils
+from torax._src import state as state_lib
+from torax._src.geometry import geometry as geometry_lib
+from torax._src.imas_tools.input.core_sources import _IMAS_SOURCE_ID_TO_TORAX_SOURCE_MAPPING
+from torax._src.output_tools import output
+from torax._src.output_tools import post_processing
+from torax._src.physics import psi_calculations
+from torax._src.sources import source_profiles
+from torax._src.torax_pydantic import model_config
+
+_TORAX_SOURCE_NAME_TO_IMAS_SOURCE_ID = {
+    entry.torax_source_name: imas_id
+    for imas_id, entry in _IMAS_SOURCE_ID_TO_TORAX_SOURCE_MAPPING.items()
+}
+
+_IMAS_SOURCE_ID_TO_IDENTIFIER_INDEX = {
+    "total": 1,
+    "ec": 3,
+    "ic": 5,
+    "fusion": 6,
+    "ohmic": 7,
+    "bremsstrahlung": 8,
+    "collisional_equipartition": 11,
+    "bootstrap_current": 13,
+    "pellet": 14,
+    "gas_puff": 108,
+    "cyclotron_synchrotron_radiation": 202,
+    "impurity_radiation": 203,
+}
+
+
+def core_sources_to_IMAS(
+    torax_config: model_config.ToraxConfig,
+    post_processed_outputs: Sequence[post_processing.PostProcessedOutputs],
+    core_profiles: Sequence[state_lib.CoreProfiles],
+    core_sources: Sequence[source_profiles.SourceProfiles],
+    geometry: Sequence[geometry_lib.Geometry],
+    times: array_typing.FloatVector,
+    ids: ids_toplevel.IDSToplevel | None = None,
+) -> ids_toplevel.IDSToplevel:
+  """Save TORAX source profiles into an IMAS core_sources IDS."""
+  if ids is None:
+    ids = imas.IDSFactory().core_sources()
+  elif ids.metadata.name != "core_sources":
+    raise TypeError(f"Expected core_sources IDS, got {ids.metadata.name} IDS.")
+
+  _fill_metadata(ids)
+  ids.time = times
+
+  # Identify all active sources across dictionaries
+  active_sources = set()
+  for cs in core_sources:
+    active_sources.update(cs.T_e.keys())
+    active_sources.update(cs.T_i.keys())
+    active_sources.update(cs.n_e.keys())
+    active_sources.update(cs.psi.keys())
+    active_sources.update(cs.fast_ions.keys())
+    # Add qei if coefficients are computed.
+    if hasattr(cs, "qei") and cs.qei is not None:
+      if np.any(np.abs(cs.qei.qei_coef) > 0.0):
+        active_sources.add("qei")
+
+  sorted_sources = sorted(list(active_sources))
+  ids.source.resize(len(sorted_sources))
+
+  for idx, src_name in enumerate(sorted_sources):
+    imas_name = _TORAX_SOURCE_NAME_TO_IMAS_SOURCE_ID.get(src_name, src_name)
+    source_node = ids.source[idx]
+    source_node.identifier.name = imas_name
+    source_node.identifier.index = _IMAS_SOURCE_ID_TO_IDENTIFIER_INDEX.get(
+        imas_name, 0
+    )
+
+    source_node.profiles_1d.resize(len(times))
+    source_node.global_quantities.resize(len(times))
+
+    for i in range(len(times)):
+      t = times[i]
+      geo = geometry[i]
+      cs_state = core_sources[i]
+      core_profile_state = core_profiles[i]
+      ppo = post_processed_outputs[i]
+
+      source_node.profiles_1d[i].time = t
+      source_node.global_quantities[i].time = t
+
+      _fill_grid_coordinates(source_node.profiles_1d[i], geo)
+          source_node.profiles_1d[i],
+          source_node.global_quantities[i],
+
+  return ids
+
+
+def _fill_metadata(ids: ids_toplevel.IDSToplevel):
+  """Fills metadata in-place for the core_sources IDS."""
+  ids.ids_properties.comment = (
+      "IDS built from TORAX simulation source profiles. Grid based on TORAX "
+      "cell grid + boundaries."
+  )
+  ids.ids_properties.homogeneous_time = 1
+  ids.ids_properties.creation_date = datetime.date.today().isoformat()
+  ids.code.name = "TORAX"
+  ids.code.description = (
+      "TORAX is a differentiable tokamak core transport simulator."
+  )
+  ids.code.repository = "https://github.com/google-deepmind/torax"
+
+
+def _fill_grid_coordinates(
+    profiles_1d_slice: imas.ids_structure.IDSStructure,
+    geo: geometry_lib.Geometry,
+) -> None:
+  """Fills 1D grid coordinates for a given time slice."""
+  grid = profiles_1d_slice.grid
+  grid.rho_tor_norm = np.concatenate([[0.0], geo.rho_norm, [1.0]])
+  grid.rho_tor = np.concatenate([[0.0], geo.rho, [geo.rho_b]])
+  grid.volume = _extend_cell_profile_to_boundaries(geo.volume, geo)
+  grid.area = _extend_cell_profile_to_boundaries(geo.area, geo)
+
+
+def _extend_cell_profile_to_boundaries(
+    cell_val: np.ndarray,
+    geo: geometry_lib.Geometry,
+) -> np.ndarray:
+  """Extends cell-centered profile to boundaries."""
+  face_val = math_utils.cell_to_face(cell_val, geo)
+  return output.extend_cell_grid_to_boundaries(
+      [cell_val], np.array([face_val])
+  )[0]
+

--- a/torax/_src/imas_tools/output/core_sources.py
+++ b/torax/_src/imas_tools/output/core_sources.py
@@ -94,6 +94,12 @@ def core_sources_to_IMAS(
     source_node.identifier.index = _IMAS_SOURCE_ID_TO_IDENTIFIER_INDEX.get(
         imas_name, 0
     )
+    if imas_name == "custom_1":
+      source_node.identifier.description = "TORAX generic current source"
+    if imas_name == "custom_2":
+      source_node.identifier.description = "TORAX generic heating source"
+    if imas_name == "custom_3":
+      source_node.identifier.description = "TORAX generic particle source"
 
     source_node.profiles_1d.resize(len(times))
     source_node.global_quantities.resize(len(times))

--- a/torax/_src/imas_tools/output/core_sources.py
+++ b/torax/_src/imas_tools/output/core_sources.py
@@ -109,7 +109,15 @@ def core_sources_to_IMAS(
       source_node.global_quantities[i].time = t
 
       _fill_grid_coordinates(source_node.profiles_1d[i], geo)
+      _fill_profiles_1d(
           source_node.profiles_1d[i],
+          cs_state,
+          core_profile_state,
+          ppo,
+          geo,
+          torax_config,
+          src_name,
+      )
           source_node.global_quantities[i],
 
   return ids
@@ -151,4 +159,64 @@ def _extend_cell_profile_to_boundaries(
   return output.extend_cell_grid_to_boundaries(
       [cell_val], np.array([face_val])
   )[0]
+
+
+def _fill_profiles_1d(
+    profiles_1d_slice: imas.ids_structure.IDSStructure,
+    cs_state: source_profiles.SourceProfiles,
+    core_profile_state: state_lib.CoreProfiles,
+    ppo: post_processing.PostProcessedOutputs,
+    geo: geometry_lib.Geometry,
+    torax_config: model_config.ToraxConfig,
+    src_name: str,
+) -> None:
+  """Fills 1D profiles for a source at a single time slice."""
+  energy_el_cell = np.zeros_like(geo.rho)
+  energy_ion_cell = np.zeros_like(geo.rho)
+  particles_el_cell = np.zeros_like(geo.rho)
+  j_par_cell = np.zeros_like(geo.rho)
+  # qei source stored differently so needs to be handled separately
+  if src_name == "qei":
+    # qei represents power to ions
+    qei_val = cs_state.qei.qei_coef * (
+        core_profile_state.T_e.value - core_profile_state.T_i.value
+    )
+    energy_ion_cell = qei_val
+    energy_el_cell = -qei_val
+  else:
+    energy_el_cell = cs_state.T_e.get(src_name, energy_el_cell)
+    energy_ion_cell = cs_state.T_i.get(src_name, energy_ion_cell)
+    particles_el_cell = cs_state.n_e.get(src_name, particles_el_cell)
+    j_par_cell = cs_state.psi.get(src_name, j_par_cell)
+
+  profiles_1d_slice.electrons.energy = _extend_cell_profile_to_boundaries(
+      energy_el_cell, geo
+  )
+  profiles_1d_slice.total_ion_energy = _extend_cell_profile_to_boundaries(
+      energy_ion_cell, geo
+  )
+  profiles_1d_slice.electrons.particles = _extend_cell_profile_to_boundaries(
+      particles_el_cell, geo
+  )
+  # TODO(b/335204606): Clean this up once we finalize our COCOS convention.
+  # Currents sign flipped due to the difference between TORAX COCOS convention
+  # and IMAS COCOS.
+  profiles_1d_slice.j_parallel = -1.0 * _extend_cell_profile_to_boundaries(
+      j_par_cell, geo
+  )
+
+  # TODO: Map Ion Species-Specific Particle Sources. For this we
+  # will need to know which ion(s) each source is affecting. For now we just
+  # create the ion substructure for all ions (including impurities) without
+  # filling the profiles.
+  main_ions = list(core_profile_state.main_ion_fractions.keys())
+  impurities = list(core_profile_state.impurity_fractions.keys())
+  all_ions = main_ions + impurities
+  profiles_1d_slice.ion.resize(len(all_ions))
+  for k, symbol in enumerate(all_ions):
+    ion_properties = constants.ION_PROPERTIES_DICT[symbol]
+    profiles_1d_slice.ion[k].name = symbol
+    profiles_1d_slice.ion[k].element.resize(1)
+    profiles_1d_slice.ion[k].element[0].a = ion_properties.A
+    profiles_1d_slice.ion[k].element[0].z_n = ion_properties.Z
 

--- a/torax/_src/imas_tools/output/tests/core_sources_test.py
+++ b/torax/_src/imas_tools/output/tests/core_sources_test.py
@@ -1,0 +1,185 @@
+# Copyright 2026 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for mapping TORAX sources to IMAS core_sources IDS."""
+
+import pathlib
+
+from absl.testing import absltest
+import imas
+import numpy as np
+from torax._src.imas_tools.input import loader
+from torax._src.imas_tools.input.core_sources import sources_from_IMAS
+from torax._src.imas_tools.output.core_sources import _TORAX_SOURCE_NAME_TO_IMAS_SOURCE_ID
+from torax._src.imas_tools.output.core_sources import core_sources_to_IMAS
+from torax._src.orchestration import run_loop
+from torax._src.orchestration import run_simulation
+from torax._src.output_tools import output
+from torax._src.test_utils import sim_test_case
+from torax._src.torax_pydantic import model_config
+
+
+class CoreSourcesTest(sim_test_case.SimTestCase):
+
+  def test_save_sources_to_IMAS(self):
+    """Checks that multiple time slices of sources can be saved into an IDS."""
+    rtol = 1e-6
+    atol = 1e-8
+
+    config = self._get_config_dict("test_iterhybrid_rampup_short.py")
+    config["numerics"]["t_final"] = 0.02
+    torax_config = model_config.ToraxConfig.from_dict(config)
+
+    (
+        initial_state,
+        post_processed_outputs,
+        step_fn,
+    ) = run_simulation.prepare_simulation(torax_config)
+
+    state_history, post_processed_outputs_history, sim_error = (
+        run_loop.run_loop(
+            initial_state=initial_state,
+            initial_post_processed_outputs=post_processed_outputs,
+            step_fn=step_fn,
+            log_timestep_info=False,
+            progress_bar=False,
+        )
+    )
+
+    state_history = output.StateHistory(
+        state_history=state_history,
+        post_processed_outputs_history=post_processed_outputs_history,
+        sim_error=sim_error,
+        torax_config=torax_config,
+    )
+
+    # Save output sources to IDS
+    filled_ids = core_sources_to_IMAS(
+        torax_config,
+        state_history.post_processed_outputs,
+        state_history.core_profiles,
+        state_history.source_profiles,
+        state_history.geometries,
+        state_history.times,
+    )
+
+    # Validate the output mapping
+    filled_ids.validate()
+    np.testing.assert_allclose(filled_ids.time, state_history.times)
+    source_names = [str(src.identifier.name) for src in filled_ids.source]
+    self.assertIn("fusion", source_names)
+
+    # Check identifier indices are mapped correctly
+    for src in filled_ids.source:
+      name = str(src.identifier.name)
+      if name == "fusion":
+        self.assertEqual(src.identifier.index, 6)
+      elif name == "ec":
+        self.assertEqual(src.identifier.index, 3)
+      elif name == "pellet":
+        self.assertEqual(src.identifier.index, 14)
+
+    # Check fusion source IMAS output against TORAX for the first time slice.
+    for src in filled_ids.source:
+      if str(src.identifier.name) == "fusion":
+        expected_T_e = state_history.source_profiles[0].T_e["fusion"]
+        actual_T_e = src.profiles_1d[0].electrons.energy[1:-1]
+        np.testing.assert_allclose(
+            actual_T_e, expected_T_e, rtol=rtol, atol=atol
+        )
+
+        expected_T_i = state_history.source_profiles[0].T_i["fusion"]
+        actual_T_i = src.profiles_1d[0].total_ion_energy[1:-1]
+        np.testing.assert_allclose(
+            actual_T_i, expected_T_i, rtol=rtol, atol=atol
+        )
+        break
+
+  def test_round_trip_with_IMAS_sources(self):
+    """Tests a round trip (IMAS -> TORAX -> IMAS) using the input core_sources test IDS."""
+    rtol = 1e-6
+    atol = 1e-8
+
+    directory = pathlib.Path(__file__).parent.parent.parent / "input" / "tests"
+    ids_in = loader.load_imas_data(
+        "core_sources_ddv4.nc", "core_sources", directory=directory
+    )
+
+    # Update TORAX simulation config with IMAS sources
+    imas_sources = sources_from_IMAS(ids_in, load_only_external_sources=True)
+
+    config = self._get_config_dict("test_iterhybrid_rampup_short.py")
+    config["sources"] |= imas_sources
+    torax_config = model_config.ToraxConfig.from_dict(config)
+
+    # Prepare simulation
+    initial_state, post_processed_outputs, _ = (
+        run_simulation.prepare_simulation(torax_config)
+    )
+
+    # Save initial state back to IMAS IDS
+    core_profiles = [initial_state.core_profiles]
+    core_sources = [initial_state.core_sources]
+    geometry = [initial_state.geometry]
+    times = np.array([initial_state.t])
+    post_processed_outputs_seq = [post_processed_outputs]
+
+    filled_ids = core_sources_to_IMAS(
+        torax_config,
+        post_processed_outputs_seq,
+        core_profiles,
+        core_sources,
+        geometry,
+        times,
+    )
+
+    # Check that the exported IC and EC IDS profiles match the input IDS ones.
+    for src_out in filled_ids.source:
+      src_name = str(src_out.identifier.name)
+      if src_name not in ["ec", "ic"]:
+        continue
+
+      grid_out = src_out.profiles_1d[0].grid.rho_tor_norm
+      expected_T_e = np.zeros_like(grid_out)
+      expected_T_i = np.zeros_like(grid_out)
+      expected_psi = np.zeros_like(grid_out)
+
+      # Combine source profiles in ids_in corresponding to the same source
+      # as there are 2 EC sources (one for each launcher) for example.
+      for source in ids_in.source:
+        if str(source.identifier.name) == src_name:
+          p1d = source.profiles_1d[0]
+          grid_in = p1d.grid.rho_tor_norm
+
+          expected_T_e += np.interp(grid_out, grid_in, p1d.electrons.energy)
+          expected_T_i += np.interp(grid_out, grid_in, p1d.total_ion_energy)
+          expected_psi += np.interp(grid_out, grid_in, p1d.j_parallel)
+
+      # Check output profiles against input ones
+      actual = src_out.profiles_1d[0].electrons.energy
+      np.testing.assert_allclose(
+          actual[1:-1], expected_T_e[1:-1], rtol=rtol, atol=atol
+      )
+      actual = src_out.profiles_1d[0].total_ion_energy
+      np.testing.assert_allclose(
+          actual[1:-1], expected_T_i[1:-1], rtol=rtol, atol=atol
+      )
+      actual = src_out.profiles_1d[0].j_parallel
+      np.testing.assert_allclose(
+          actual[1:-1], expected_psi[1:-1], rtol=rtol, atol=atol
+      )
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/torax/_src/imas_tools/output/tests/core_sources_test.py
+++ b/torax/_src/imas_tools/output/tests/core_sources_test.py
@@ -79,16 +79,9 @@ class CoreSourcesTest(sim_test_case.SimTestCase):
     np.testing.assert_allclose(filled_ids.time, state_history.times)
     source_names = [str(src.identifier.name) for src in filled_ids.source]
     self.assertIn("fusion", source_names)
-
-    # Check identifier indices are mapped correctly
-    for src in filled_ids.source:
-      name = str(src.identifier.name)
-      if name == "fusion":
-        self.assertEqual(src.identifier.index, 6)
-      elif name == "ec":
-        self.assertEqual(src.identifier.index, 3)
-      elif name == "pellet":
-        self.assertEqual(src.identifier.index, 14)
+    self.assertIn("pellet", source_names)
+    self.assertIn("gas_puff", source_names)
+    # self.assertIn("collisional_equipartition", source_names)
 
     # Check fusion source IMAS output against TORAX for the first time slice.
     for src in filled_ids.source:
@@ -144,6 +137,13 @@ class CoreSourcesTest(sim_test_case.SimTestCase):
         times,
     )
 
+    source_names = [str(src.identifier.name) for src in filled_ids.source]
+    self.assertIn("fusion", source_names)
+    self.assertIn("pellet", source_names)
+    self.assertIn("gas_puff", source_names)
+    self.assertIn("collisional_equipartition", source_names)
+    self.assertIn("ec", source_names)
+    self.assertIn("ic", source_names)
     # Check that the exported IC and EC IDS profiles match the input IDS ones.
     for src_out in filled_ids.source:
       src_name = str(src_out.identifier.name)

--- a/torax/_src/imas_tools/output/tests/core_sources_test.py
+++ b/torax/_src/imas_tools/output/tests/core_sources_test.py
@@ -145,9 +145,9 @@ class CoreSourcesTest(sim_test_case.SimTestCase):
     self.assertIn("pellet", source_names)
     self.assertIn("gas_puff", source_names)
     self.assertIn("collisional_equipartition", source_names)
-    self.assertIn("generic_current", source_names)
-    self.assertIn("generic_heat", source_names)
-    self.assertIn("generic_particle", source_names)
+    self.assertIn("custom_1", source_names)
+    self.assertIn("custom_2", source_names)
+    self.assertIn("custom_3", source_names)
     self.assertIn("ec", source_names)
     self.assertIn("ic", source_names)
     # Check that the exported IC and EC IDS profiles match the input IDS ones.

--- a/torax/_src/imas_tools/output/tests/core_sources_test.py
+++ b/torax/_src/imas_tools/output/tests/core_sources_test.py
@@ -81,6 +81,9 @@ class CoreSourcesTest(sim_test_case.SimTestCase):
     self.assertIn("fusion", source_names)
     self.assertIn("pellet", source_names)
     self.assertIn("gas_puff", source_names)
+    self.assertIn("generic_current", source_names)
+    self.assertIn("generic_heat", source_names)
+    self.assertIn("generic_particle", source_names)
     # self.assertIn("collisional_equipartition", source_names)
 
     # Check fusion source IMAS output against TORAX for the first time slice.
@@ -142,6 +145,9 @@ class CoreSourcesTest(sim_test_case.SimTestCase):
     self.assertIn("pellet", source_names)
     self.assertIn("gas_puff", source_names)
     self.assertIn("collisional_equipartition", source_names)
+    self.assertIn("generic_current", source_names)
+    self.assertIn("generic_heat", source_names)
+    self.assertIn("generic_particle", source_names)
     self.assertIn("ec", source_names)
     self.assertIn("ic", source_names)
     # Check that the exported IC and EC IDS profiles match the input IDS ones.

--- a/torax/_src/imas_tools/sources_mapping.py
+++ b/torax/_src/imas_tools/sources_mapping.py
@@ -27,6 +27,9 @@ from torax._src.sources import qei_source
 from torax._src.sources import source as source_module
 from torax._src.sources.impurity_radiation_heat_sink import impurity_radiation_heat_sink
 from torax._src.sources.ion_cyclotron_source import base as ion_cyclotron_source
+from torax._src.sources import generic_ion_el_heat_source
+from torax._src.sources import generic_current_source
+from torax._src.sources import generic_particle_source
 
 
 class _SourceMappingEntry(NamedTuple):
@@ -95,8 +98,8 @@ TORAX_SOURCE_NAME_TO_IMAS_SOURCE_ID = {
 }
 # Manually add generic sources which are not in the input mapping.
 TORAX_SOURCE_NAME_TO_IMAS_SOURCE_ID.update({
-    "generic_current": "custom_1",
-    "generic_heat": "custom_2",
-    "generic_particle": "custom_3",
+    generic_current_source.GenericCurrentSource.SOURCE_NAME: "custom_1",
+    generic_ion_el_heat_source.GenericIonElectronHeatSource.SOURCE_NAME: "custom_2",
+    generic_particle_source.GenericParticleSource.SOURCE_NAME: "custom_3",
 })
 

--- a/torax/_src/imas_tools/sources_mapping.py
+++ b/torax/_src/imas_tools/sources_mapping.py
@@ -1,0 +1,102 @@
+# Copyright 2026 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Maps TORAX source names to IMAS source IDS and vice-versa."""
+
+from typing import NamedTuple
+
+from torax._src.sources import bremsstrahlung_heat_sink
+from torax._src.sources import cyclotron_radiation_heat_sink
+from torax._src.sources import electron_cyclotron_source
+from torax._src.sources import fusion_heat_source
+from torax._src.sources import gas_puff_source
+from torax._src.sources import ohmic_heat_source
+from torax._src.sources import pellet_source
+from torax._src.sources import qei_source
+from torax._src.sources import source as source_module
+from torax._src.sources.impurity_radiation_heat_sink import impurity_radiation_heat_sink
+from torax._src.sources.ion_cyclotron_source import base as ion_cyclotron_source
+
+
+class _SourceMappingEntry(NamedTuple):
+  affected_core_profiles: tuple[source_module.AffectedCoreProfile, ...]
+  torax_source_name: str
+  is_external: bool
+
+
+IMAS_SOURCE_ID_TO_TORAX_SOURCE_MAPPING = {
+    # External fuelling and HCD sources
+    "pellet": _SourceMappingEntry(
+        pellet_source.PelletSource.AFFECTED_CORE_PROFILES,
+        pellet_source.PelletSource.SOURCE_NAME,
+        True,
+    ),
+    "gas_puff": _SourceMappingEntry(
+        gas_puff_source.GasPuffSource.AFFECTED_CORE_PROFILES,
+        gas_puff_source.GasPuffSource.SOURCE_NAME,
+        True,
+    ),
+    "ec": _SourceMappingEntry(
+        electron_cyclotron_source.ElectronCyclotronSource.AFFECTED_CORE_PROFILES,
+        electron_cyclotron_source.ElectronCyclotronSource.SOURCE_NAME,
+        True,
+    ),
+    "ic": _SourceMappingEntry(
+        ion_cyclotron_source.IonCyclotronSource.AFFECTED_CORE_PROFILES,
+        ion_cyclotron_source.IonCyclotronSource.SOURCE_NAME,
+        True,
+    ),
+    "ohmic": _SourceMappingEntry(
+        ohmic_heat_source.OhmicHeatSource.AFFECTED_CORE_PROFILES,
+        ohmic_heat_source.OhmicHeatSource.SOURCE_NAME,
+        False,
+    ),
+    "fusion": _SourceMappingEntry(
+        fusion_heat_source.FusionHeatSource.AFFECTED_CORE_PROFILES,
+        fusion_heat_source.FusionHeatSource.SOURCE_NAME,
+        False,
+    ),
+    "collisional_equipartition": _SourceMappingEntry(
+        qei_source.QeiSource.AFFECTED_CORE_PROFILES,
+        qei_source.QeiSource.SOURCE_NAME,
+        False,
+    ),
+    "cyclotron_radiation": _SourceMappingEntry(
+        cyclotron_radiation_heat_sink.CyclotronRadiationHeatSink.AFFECTED_CORE_PROFILES,
+        cyclotron_radiation_heat_sink.CyclotronRadiationHeatSink.SOURCE_NAME,
+        False,
+    ),
+    "bremsstrahlung": _SourceMappingEntry(
+        bremsstrahlung_heat_sink.BremsstrahlungHeatSink.AFFECTED_CORE_PROFILES,
+        bremsstrahlung_heat_sink.BremsstrahlungHeatSink.SOURCE_NAME,
+        False,
+    ),
+    "impurity_radiation": _SourceMappingEntry(
+        impurity_radiation_heat_sink.ImpurityRadiationHeatSink.AFFECTED_CORE_PROFILES,
+        impurity_radiation_heat_sink.ImpurityRadiationHeatSink.SOURCE_NAME,
+        False,
+    ),
+}
+
+TORAX_SOURCE_NAME_TO_IMAS_SOURCE_ID = {
+    entry.torax_source_name: imas_id
+    for imas_id, entry in IMAS_SOURCE_ID_TO_TORAX_SOURCE_MAPPING.items()
+}
+# Manually add generic sources which are not in the input mapping.
+TORAX_SOURCE_NAME_TO_IMAS_SOURCE_ID.update({
+    "generic_current": "custom_1",
+    "generic_heat": "custom_2",
+    "generic_particle": "custom_3",
+})
+


### PR DESCRIPTION
Addition to also map the TORAX generic sources to IMAS. Using the custom identifiers from  https://imas-data-dictionary.readthedocs.io/en/latest/generated/identifier/core_source_identifier.html#identifier-core_sources-core_source_identifier.xml, and adds description to be more explicit.