### PR TITLE
Followup PR: Implement IMAS output core_sources mapping 

### DIFF
--- a/torax/_src/imas_tools/output/core_sources.py
+++ b/torax/_src/imas_tools/output/core_sources.py
@@ -56,45 +56,44 @@ def core_sources_to_IMAS(
   ids.source.resize(len(active_sources))
 
   for source_name, source_node in zip(active_sources, ids.source, strict=True):
-    if not "generic" in source_name:
-      imas_name = sources_mapping.TORAX_SOURCE_NAME_TO_IMAS_SOURCE_ID[source_name]
-      source_node.identifier.name = imas_name
-      # TODO(b/323504363): b/459479939 - i/2233: Add identifier in once a mapping is available
-      # in IMAS-python https://github.com/iterorganization/IMAS-Python/issues/134
-      if imas_name == "custom_1":
-        source_node.identifier.description = "TORAX generic current source"
-      if imas_name == "custom_2":
-        source_node.identifier.description = "TORAX generic heating source"
-      if imas_name == "custom_3":
-        source_node.identifier.description = "TORAX generic particle source"
+    imas_name = sources_mapping.TORAX_SOURCE_NAME_TO_IMAS_SOURCE_ID[source_name]
+    source_node.identifier.name = imas_name
+    # TODO(b/323504363): b/459479939 - i/2233: Add identifier in once a mapping is available
+    # in IMAS-python https://github.com/iterorganization/IMAS-Python/issues/134
+    if imas_name == "custom_1":
+      source_node.identifier.description = "TORAX generic current source"
+    if imas_name == "custom_2":
+      source_node.identifier.description = "TORAX generic heating source"
+    if imas_name == "custom_3":
+      source_node.identifier.description = "TORAX generic particle source"
 
-      source_node.profiles_1d.resize(num_times)
-      source_node.global_quantities.resize(num_times)
+    source_node.profiles_1d.resize(num_times)
+    source_node.global_quantities.resize(num_times)
 
-      for i in range(num_times):
-        t = times[i]
-        geo = geometry[i]
-        core_source_state = core_sources[i]
-        core_profile_state = core_profiles[i]
+    for i in range(num_times):
+      t = times[i]
+      geo = geometry[i]
+      core_source_state = core_sources[i]
+      core_profile_state = core_profiles[i]
 
-        source_node.profiles_1d[i].time = t
-        source_node.global_quantities[i].time = t
+      source_node.profiles_1d[i].time = t
+      source_node.global_quantities[i].time = t
 
-        _fill_grid_coordinates(source_node.profiles_1d[i], geo)
-        _fill_profiles_1d(
-            source_node.profiles_1d[i],
-            core_source_state,
-            core_profile_state,
-            geo,
-            source_name,
-        )
-        _fill_global_quantities(
-            source_node.global_quantities[i],
-            core_source_state,
-            core_profile_state,
-            geo,
-            source_name,
-        )
+      _fill_grid_coordinates(source_node.profiles_1d[i], geo)
+      _fill_profiles_1d(
+          source_node.profiles_1d[i],
+          core_source_state,
+          core_profile_state,
+          geo,
+          source_name,
+      )
+      _fill_global_quantities(
+          source_node.global_quantities[i],
+          core_source_state,
+          core_profile_state,
+          geo,
+          source_name,
+      )
 
   return ids
 

--- a/torax/_src/imas_tools/output/core_sources.py
+++ b/torax/_src/imas_tools/output/core_sources.py
@@ -61,6 +61,13 @@ def core_sources_to_IMAS(
       source_node.identifier.name = imas_name
       # TODO(b/323504363): b/459479939 - i/2233: Add identifier in once a mapping is available
       # in IMAS-python https://github.com/iterorganization/IMAS-Python/issues/134
+      if imas_name == "custom_1":
+        source_node.identifier.description = "TORAX generic current source"
+      if imas_name == "custom_2":
+        source_node.identifier.description = "TORAX generic heating source"
+      if imas_name == "custom_3":
+        source_node.identifier.description = "TORAX generic particle source"
+
       source_node.profiles_1d.resize(num_times)
       source_node.global_quantities.resize(num_times)
 

--- a/torax/_src/imas_tools/output/tests/core_sources_test.py
+++ b/torax/_src/imas_tools/output/tests/core_sources_test.py
@@ -136,9 +136,9 @@ class CoreSourcesTest(sim_test_case.SimTestCase):
     self.assertIn("pellet", source_names)
     self.assertIn("gas_puff", source_names)
     self.assertIn("collisional_equipartition", source_names)
-    self.assertIn("generic_current", source_names)
-    self.assertIn("generic_heat", source_names)
-    self.assertIn("generic_particle", source_names)
+    self.assertIn("custom_1", source_names)
+    self.assertIn("custom_2", source_names)
+    self.assertIn("custom_3", source_names)
     self.assertIn("ec", source_names)
     self.assertIn("ic", source_names)
     # Check that the exported IC and EC IDS profiles match the input IDS ones.

--- a/torax/_src/imas_tools/output/tests/core_sources_test.py
+++ b/torax/_src/imas_tools/output/tests/core_sources_test.py
@@ -77,10 +77,10 @@ class CoreSourcesTest(sim_test_case.SimTestCase):
     self.assertIn("fusion", source_names)
     self.assertIn("pellet", source_names)
     self.assertIn("gas_puff", source_names)
-    self.assertIn("generic_current", source_names)
-    self.assertIn("generic_heat", source_names)
-    self.assertIn("generic_particle", source_names)
-    # self.assertIn("collisional_equipartition", source_names)
+    self.assertIn("custom_1", source_names)
+    self.assertIn("custom_2", source_names)
+    self.assertIn("custom_3", source_names)
+    self.assertIn("collisional_equipartition", source_names)
 
     # Check fusion source IMAS output against TORAX for the first time slice.
     for source in filled_ids.source:
@@ -165,17 +165,11 @@ class CoreSourcesTest(sim_test_case.SimTestCase):
 
       # Check output profiles against input ones
       actual = source_out.profiles_1d[0].electrons.energy
-      np.testing.assert_allclose(
-          actual, expected_T_e, rtol=rtol, atol=atol
-      )
+      np.testing.assert_allclose(actual, expected_T_e, rtol=rtol, atol=atol)
       actual = source_out.profiles_1d[0].total_ion_energy
-      np.testing.assert_allclose(
-          actual, expected_T_i, rtol=rtol, atol=atol
-      )
+      np.testing.assert_allclose(actual, expected_T_i, rtol=rtol, atol=atol)
       actual = source_out.profiles_1d[0].j_parallel
-      np.testing.assert_allclose(
-          actual, expected_psi, rtol=rtol, atol=atol
-      )
+      np.testing.assert_allclose(actual, expected_psi, rtol=rtol, atol=atol)
 
 
 if __name__ == "__main__":

--- a/torax/_src/imas_tools/output/tests/core_sources_test.py
+++ b/torax/_src/imas_tools/output/tests/core_sources_test.py
@@ -77,6 +77,9 @@ class CoreSourcesTest(sim_test_case.SimTestCase):
     self.assertIn("fusion", source_names)
     self.assertIn("pellet", source_names)
     self.assertIn("gas_puff", source_names)
+    self.assertIn("generic_current", source_names)
+    self.assertIn("generic_heat", source_names)
+    self.assertIn("generic_particle", source_names)
     # self.assertIn("collisional_equipartition", source_names)
 
     # Check fusion source IMAS output against TORAX for the first time slice.
@@ -133,6 +136,9 @@ class CoreSourcesTest(sim_test_case.SimTestCase):
     self.assertIn("pellet", source_names)
     self.assertIn("gas_puff", source_names)
     self.assertIn("collisional_equipartition", source_names)
+    self.assertIn("generic_current", source_names)
+    self.assertIn("generic_heat", source_names)
+    self.assertIn("generic_particle", source_names)
     self.assertIn("ec", source_names)
     self.assertIn("ic", source_names)
     # Check that the exported IC and EC IDS profiles match the input IDS ones.

--- a/torax/_src/imas_tools/sources_mapping.py
+++ b/torax/_src/imas_tools/sources_mapping.py
@@ -27,6 +27,9 @@ from torax._src.sources import qei_source
 from torax._src.sources import source as source_module
 from torax._src.sources.impurity_radiation_heat_sink import impurity_radiation_heat_sink
 from torax._src.sources.ion_cyclotron_source import base as ion_cyclotron_source
+from torax._src.sources import generic_ion_el_heat_source
+from torax._src.sources import generic_current_source
+from torax._src.sources import generic_particle_source
 
 
 class _SourceMappingEntry(NamedTuple):
@@ -96,8 +99,9 @@ TORAX_SOURCE_NAME_TO_IMAS_SOURCE_ID: Final[dict[str, str]] = {
         entry.torax_source_name: imas_id
         for imas_id, entry in IMAS_SOURCE_ID_TO_TORAX_SOURCE_MAPPING.items()
     },
-    "generic_current": "custom_1",
-    "generic_heat": "custom_2",
-    "generic_particle": "custom_3",
+    generic_current_source.GenericCurrentSource.SOURCE_NAME: "custom_1",
+    generic_ion_el_heat_source.GenericIonElectronHeatSource.SOURCE_NAME: "custom_2",
+    generic_particle_source.GenericParticleSource.SOURCE_NAME: "custom_3",
 }
+
 

--- a/torax/_src/imas_tools/sources_mapping.py
+++ b/torax/_src/imas_tools/sources_mapping.py
@@ -92,6 +92,12 @@ IMAS_SOURCE_ID_TO_TORAX_SOURCE_MAPPING: Final[
 }
 
 TORAX_SOURCE_NAME_TO_IMAS_SOURCE_ID: Final[dict[str, str]] = {
-    entry.torax_source_name: imas_id
-    for imas_id, entry in IMAS_SOURCE_ID_TO_TORAX_SOURCE_MAPPING.items()
+    **{
+        entry.torax_source_name: imas_id
+        for imas_id, entry in IMAS_SOURCE_ID_TO_TORAX_SOURCE_MAPPING.items()
+    },
+    "generic_current": "custom_1",
+    "generic_heat": "custom_2",
+    "generic_particle": "custom_3",
 }
+


### PR DESCRIPTION
Addition to also map the TORAX generic sources to IMAS. Using the custom identifiers from https://imas-data-dictionary.readthedocs.io/en/latest/generated/identifier/core_source_identifier.html#identifier-core_sources-core_source_identifier.xml, and adds description to be more explicit.