### PR TITLE
fix: support plotting initial conditions and empty datasets (Issue #1…

### DIFF
--- a/torax/_src/plotting/plotruns_lib.py
+++ b/torax/_src/plotting/plotruns_lib.py
@@ -574,7 +574,11 @@ def _get_limit(
     include_first_timepoint: bool,
 ) -> float:
   """Gets the limit for a set of attributes based a histogram percentile."""
-  if include_first_timepoint:
+  time_steps = len(plotdata.t)
+  if time_steps == 0:
+    raise ValueError(f"No timepoints found in dataset for attributes {attrs}.")
+
+  if include_first_timepoint or time_steps == 1:
     values = np.concatenate(
         [getattr(plotdata, attr).flatten() for attr in attrs]
     )
@@ -582,6 +586,10 @@ def _get_limit(
     values = np.concatenate(
         [getattr(plotdata, attr)[1:, :].flatten() for attr in attrs]
     )
+
+  if values.size == 0:
+    raise ValueError(f"No data supplied for attributes {attrs}.")
+
   return np.percentile(values, percentile)
 
 

--- a/torax/_src/plotting/plotruns_lib_test.py
+++ b/torax/_src/plotting/plotruns_lib_test.py
@@ -77,6 +77,46 @@ class PlotrunsLibTest(parameterized.TestCase):
         fig, go.Figure, msg=f'Plotting of {test_data_path.name} failed'
     )
 
+  def test_get_limit_with_one_timepoint(self):
+    profiles_ds = xr.Dataset({
+        'T_i': (('time', 'rho'), [[1.0, 2.0]]),
+    })
+    top_level_ds = xr.Dataset({'time': [0.0]})
+    data_tree = xr.DataTree(
+        dataset=top_level_ds,
+        children={
+            'profiles': xr.DataTree(dataset=profiles_ds),
+            'scalars': xr.DataTree(dataset=xr.Dataset()),
+            'numerics': xr.DataTree(dataset=xr.Dataset()),
+        },
+    )
+    plot_data = plotruns_lib.PlotData(data_tree=data_tree)
+
+    limit = plotruns_lib._get_limit(
+        plot_data, ('T_i',), 100.0, include_first_timepoint=False
+    )
+    self.assertEqual(limit, 2.0)
+
+  def test_get_limit_with_empty_dataset(self):
+    profiles_ds = xr.Dataset({
+        'T_i': (('time', 'rho'), np.empty((0, 2))),
+    })
+    top_level_ds = xr.Dataset({'time': []})
+    data_tree = xr.DataTree(
+        dataset=top_level_ds,
+        children={
+            'profiles': xr.DataTree(dataset=profiles_ds),
+            'scalars': xr.DataTree(dataset=xr.Dataset()),
+            'numerics': xr.DataTree(dataset=xr.Dataset()),
+        },
+    )
+    plot_data = plotruns_lib.PlotData(data_tree=data_tree)
+
+    with self.assertRaisesRegex(ValueError, 'No timepoints found'):
+      plotruns_lib._get_limit(
+          plot_data, ('T_i',), 100.0, include_first_timepoint=False
+      )
+
 
 class FigurePropertiesTest(absltest.TestCase):
 


### PR DESCRIPTION
Fixes #1369.

This PR resolves an `IndexError` thrown when attempting to use `plot_runs` on a state dictionary containing solely the initial conditions (e.g., `len(time_steps) == 1`). Previously, the `_get_limit` boundary computation aggressively sliced arrays (`[1:, :]`) to ignore the first time point for scale fitting, which left an empty array for single-timepoint data.

- `_get_limit` now checks `len(plotdata.t)` and falls back to including the initial condition if it's the only point available.
- Completely empty datasets now intercept the lack of data and throw an explicit, readable `ValueError(f"No data supplied for attributes {attrs}.")`.
- Test coverage added to `plotruns_lib_test.py`.
