### PR TITLE
feat: add q-profile warnings for unphysical configs (Issue #844)

### DIFF
--- a/torax/_src/orchestration/run_simulation.py
+++ b/torax/_src/orchestration/run_simulation.py
@@ -32,6 +32,8 @@ from torax._src.orchestration import sim_state
 from torax._src.orchestration import step_function
 from torax._src.output_tools import output
 from torax._src.output_tools import post_processing
+from absl import logging
+import numpy as np
 from torax._src.torax_pydantic import model_config
 import xarray as xr
 
@@ -91,6 +93,13 @@ def prepare_simulation(
         initial_state_lib.get_initial_state_and_post_processed_outputs(
             step_fn=step_fn,
         )
+    )
+
+  if np.any(np.asarray(initial_state.core_profiles.q_face) < 0.5):
+    logging.warning(
+        'The q-profile is extremely low (q < 0.5). This indicates an '
+        'unphysical configuration, possibly due to excessively high '
+        'plasma current (Ip) and/or low magnetic field (B).'
     )
 
   return (

--- a/torax/_src/orchestration/tests/run_simulation_test.py
+++ b/torax/_src/orchestration/tests/run_simulation_test.py
@@ -129,6 +129,22 @@ class RunSimulationTest(sim_test_case.SimTestCase):
         state_history.sim_error, state.SimError.DID_NOT_REACH_T_FINAL
     )
 
+  def test_q_profile_warning_logged(self):
+    torax_config = self._get_torax_config('test_iterhybrid_mockup.py')
+    # Use unphysically high Ip and low B to trigger q < 0.5
+    original_B_0 = torax_config.geometry.B_0
+    torax_config.update_fields({
+        'profile_conditions.Ip': 30e6,
+        'geometry.B_0': original_B_0 * 0.1,
+    })
+    
+    with self.assertLogs(level='WARNING') as cm:
+      run_simulation.run_simulation(torax_config, max_steps=1)
+    
+    self.assertTrue(
+        any('The q-profile is extremely low (q < 0.5)' in log for log in cm.output)
+    )
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
Fixes #844.

This PR adds a safety check inside the `run_simulation` orchestration layer. If a user provides an initial `q` profile configuration where $q < 0.5$, it now immediately fires an `absl.logging.warning` to warn the user about potential unphysical simulation behavior (like premature crashes in tearing mode or sawtooth crash calculations) rather than letting it silently fail later in the solver. 

A unit test `test_q_profile_warning_logged` has been added to `run_simulation_test.py` to ensure this warning fires correctly.
