### PR TITLE
Include IMAS example data in package installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,7 @@ exclude = ["*tests*"]
 
 [tool.setuptools.package-data]
 "torax.data.third_party.geo" = ["*"]
+"torax.data.third_party.imas" = ["*"]
 
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
The STEP example loads IMAS NetCDF assets from the installed torax package path, so package metadata needs to include torax.data.third_party.imas alongside the existing geo data.