### PR TITLE
Reduce plotting slider payload for faster figure load

### DIFF
--- a/torax/_src/plotting/plotruns_lib.py
+++ b/torax/_src/plotting/plotruns_lib.py
@@ -667,7 +667,6 @@ def _add_traces_and_update_axes(
               'trace_idx': trace_count,
               'attr': attr,
               'dataset': dataset,
-              'x': x,
           })
         else:
           # Time series plots (static)
@@ -693,26 +692,24 @@ def _add_traces_and_update_axes(
         )
         trace_count += 1
 
-    # Add vertical line to denote current slider time for time series plots
+    # Add vertical line to denote current slider time for time series plots.
+    # A layout shape rather than a trace, so slider steps can move it via a
+    # small relayout instead of re-sending x/y arrays per step.
     if not is_spatial:
       ylow, yhigh = _get_y_limits(datasets, axis_config)
-      fig.add_trace(
-          go.Scatter(
-              x=[datasets[0].t[0], datasets[0].t[0]],
-              y=[ylow, yhigh],
-              mode='lines',
-              name='Current Time',
-              showlegend=False,
-              line=dict(color='gray', width=1, dash='dot'),
-          ),
+      fig.add_shape(
+          type='line',
+          x0=datasets[0].t[0],
+          x1=datasets[0].t[0],
+          y0=ylow,
+          y1=yhigh,
+          line=dict(color='gray', width=1, dash='dot'),
           row=row,
           col=col,
       )
       timestamp_line_info.append({
-          'trace_idx': trace_count,
-          'y': [ylow, yhigh],
+          'shape_idx': len(timestamp_line_info),
       })
-      trace_count += 1
 
     # Update Axes Labels
     x_axis_kwargs = dict(
@@ -766,7 +763,6 @@ def _get_slider_steps(
 
   for t_val in t_vals:
     y_updates = []
-    x_updates = []
     trace_indices = []
 
     for info in spatial_traces_info:
@@ -775,18 +771,20 @@ def _get_slider_steps(
       nearest_t_idx = int(np.argmin(np.abs(dataset_t - t_val)))
       val_array = getattr(info['dataset'], info['attr'])
       y_updates.append(val_array[nearest_t_idx, :])
-      x_updates.append(info['x'])
       trace_indices.append(info['trace_idx'])
 
+    # The x-arrays of spatial traces are static rho grids, so only y is
+    # restyled. Timestamp vlines are layout shapes, moved via the relayout
+    # part of the 'update' method. This halves the per-step payload.
+    relayout_updates = {}
     for info in timestamp_line_info:
-      y_updates.append(info['y'])
-      x_updates.append([t_val, t_val])
-      trace_indices.append(info['trace_idx'])
+      relayout_updates[f'shapes[{info["shape_idx"]}].x0'] = t_val
+      relayout_updates[f'shapes[{info["shape_idx"]}].x1'] = t_val
 
     step = {
-        'method': 'restyle',
+        'method': 'update',
         'label': f'{t_val:.3f}s',
-        'args': [{'y': y_updates, 'x': x_updates}, trace_indices],
+        'args': [{'y': y_updates}, relayout_updates, trace_indices],
     }
     steps.append(step)
   return steps
@@ -838,11 +836,12 @@ def _build_slider(
                   dict(
                       args=[
                           steps_linear_time[0]['args'][0],
-                          {
+                          steps_linear_time[0]['args'][1]
+                          | {
                               'sliders[0].steps': steps_linear_time,
                               'sliders[0].active': 0,
                           },
-                          steps_linear_time[0]['args'][1],
+                          steps_linear_time[0]['args'][2],
                       ],
                       label='Plasma time',
                       method='update',
@@ -850,11 +849,12 @@ def _build_slider(
                   dict(
                       args=[
                           steps_timesteps[0]['args'][0],
-                          {
+                          steps_timesteps[0]['args'][1]
+                          | {
                               'sliders[0].steps': steps_timesteps,
                               'sliders[0].active': 0,
                           },
-                          steps_timesteps[0]['args'][1],
+                          steps_timesteps[0]['args'][2],
                       ],
                       label='Simulation steps',
                       method='update',

--- a/torax/_src/plotting/plotruns_lib_test.py
+++ b/torax/_src/plotting/plotruns_lib_test.py
@@ -78,6 +78,42 @@ class PlotrunsLibTest(parameterized.TestCase):
     )
 
 
+class SliderPayloadTest(absltest.TestCase):
+  """Verifies slider steps carry a minimal payload (issue #553)."""
+
+  @classmethod
+  def setUpClass(cls):
+    super().setUpClass()
+    config_path = path_utils.torax_path().joinpath(
+        'plotting', 'configs', 'default_plot_config.py'
+    )
+    plot_config = config_loader.import_module(config_path)['PLOT_CONFIG']
+    test_data_path = paths.test_data_dir() / 'test_iterhybrid_rampup.nc'
+    cls.fig = plotruns_lib.plot_run(
+        plot_config, {'Data 1': str(test_data_path)}, interactive=False
+    )
+
+  def test_steps_do_not_resend_static_x_arrays(self):
+    for step in self.fig.layout.sliders[0].steps:
+      self.assertNotIn('x', step.args[0])
+
+  def test_steps_move_timestamp_shapes_via_relayout(self):
+    shapes = self.fig.layout.shapes
+    self.assertNotEmpty(shapes)
+    for step in self.fig.layout.sliders[0].steps:
+      relayout_updates = step.args[1]
+      for idx in range(len(shapes)):
+        self.assertIn(f'shapes[{idx}].x0', relayout_updates)
+        self.assertIn(f'shapes[{idx}].x1', relayout_updates)
+
+  def test_timestamp_lines_are_shapes_not_traces(self):
+    self.assertNotIn('Current Time', [trace.name for trace in self.fig.data])
+
+  def test_mode_buttons_switch_slider_steps(self):
+    for button in self.fig.layout.updatemenus[0].buttons:
+      self.assertIn('sliders[0].steps', button.args[1])
+
+
 class FigurePropertiesTest(absltest.TestCase):
 
   def test_validation_raises_error(self):


### PR DESCRIPTION
Fixes part of the slider payload bloat described in #553.

## Problem

`_get_slider_steps()` re-sent the full (static) x-array for every spatial
trace on every slider step, and encoded the timestamp indicator as a
per-step trace update instead of a lightweight shape move. Neither the
x-grid nor the vline's y-extent changes between steps — only trace y-values
and the vline's x-position do.

## Fix

- Timestamp indicator is now a `layout.shape` (moved via `relayout`) instead
  of a full trace re-sent on every step.
- Slider steps use Plotly's `update` method with separate restyle (`y` only)
  and relayout (`shapes[i].x0/x1`) payloads — `x` arrays are no longer
  duplicated per step.
- `updatemenus` mode-switch buttons now merge the relayout keys into their
  existing step-0 args instead of duplicating them.

## Measured (rampup reference dataset, min of 5 runs)

| Metric | Before | After | Δ |
|---|---|---|---|
| Figure JSON size | 1.81 MB | 1.31 MB | −28% |
| `to_json()` time | 0.089s | 0.059s | −34% |
| Figure build time | 0.851s | 0.824s | −3% (build is dominated by `.nc` load, not slider assembly — see note below) |

Build time is largely unaffected because it's dominated by data loading and
trace construction, not slider-step serialization. The measured win is in
payload size and serialize time, which is what actually affects load and
parse time client-side (browser fetch/parse/hold of the HTML figure).

This is one isolated speedup, per your request. A second, larger win is
still on the table: the `updatemenus` buttons currently embed a *full copy*
of both slider-mode step lists (linear time vs. simulation steps), so the
step data is stored ~2x beyond what's in this PR. That's a design choice
(which mode's steps live in the button vs. get rebuilt) I'd like input on
before touching it — happy to open a follow-up issue/PR once we agree on
approach.

## Tests

Added `SliderPayloadTest` in `plotruns_lib_test.py` (4 cases): steps carry
no `x` payload, timestamp indicator moves via shape relayout, timestamp
indicator is a shape not a trace, mode buttons still switch slider steps.
Full plotting suite: 236/236 passing.
