### PR TITLE
Add config/CLI option to select a single slider mode

### DIFF
--- a/torax/_src/plotting/plotruns_lib.py
+++ b/torax/_src/plotting/plotruns_lib.py
@@ -667,7 +667,6 @@ def _add_traces_and_update_axes(
               'trace_idx': trace_count,
               'attr': attr,
               'dataset': dataset,
-              'x': x,
           })
         else:
           # Time series plots (static)
@@ -693,26 +692,24 @@ def _add_traces_and_update_axes(
         )
         trace_count += 1
 
-    # Add vertical line to denote current slider time for time series plots
+    # Add vertical line to denote current slider time for time series plots.
+    # A layout shape rather than a trace, so slider steps can move it via a
+    # small relayout instead of re-sending x/y arrays per step.
     if not is_spatial:
       ylow, yhigh = _get_y_limits(datasets, axis_config)
-      fig.add_trace(
-          go.Scatter(
-              x=[datasets[0].t[0], datasets[0].t[0]],
-              y=[ylow, yhigh],
-              mode='lines',
-              name='Current Time',
-              showlegend=False,
-              line=dict(color='gray', width=1, dash='dot'),
-          ),
+      fig.add_shape(
+          type='line',
+          x0=datasets[0].t[0],
+          x1=datasets[0].t[0],
+          y0=ylow,
+          y1=yhigh,
+          line=dict(color='gray', width=1, dash='dot'),
           row=row,
           col=col,
       )
       timestamp_line_info.append({
-          'trace_idx': trace_count,
-          'y': [ylow, yhigh],
+          'shape_idx': len(timestamp_line_info),
       })
-      trace_count += 1
 
     # Update Axes Labels
     x_axis_kwargs = dict(
@@ -766,7 +763,6 @@ def _get_slider_steps(
 
   for t_val in t_vals:
     y_updates = []
-    x_updates = []
     trace_indices = []
 
     for info in spatial_traces_info:
@@ -775,18 +771,20 @@ def _get_slider_steps(
       nearest_t_idx = int(np.argmin(np.abs(dataset_t - t_val)))
       val_array = getattr(info['dataset'], info['attr'])
       y_updates.append(val_array[nearest_t_idx, :])
-      x_updates.append(info['x'])
       trace_indices.append(info['trace_idx'])
 
+    # The x-arrays of spatial traces are static rho grids, so only y is
+    # restyled. Timestamp vlines are layout shapes, moved via the relayout
+    # part of the 'update' method. This halves the per-step payload.
+    relayout_updates = {}
     for info in timestamp_line_info:
-      y_updates.append(info['y'])
-      x_updates.append([t_val, t_val])
-      trace_indices.append(info['trace_idx'])
+      relayout_updates[f'shapes[{info["shape_idx"]}].x0'] = t_val
+      relayout_updates[f'shapes[{info["shape_idx"]}].x1'] = t_val
 
     step = {
-        'method': 'restyle',
+        'method': 'update',
         'label': f'{t_val:.3f}s',
-        'args': [{'y': y_updates, 'x': x_updates}, trace_indices],
+        'args': [{'y': y_updates}, relayout_updates, trace_indices],
     }
     steps.append(step)
   return steps
@@ -838,11 +836,12 @@ def _build_slider(
                   dict(
                       args=[
                           steps_linear_time[0]['args'][0],
-                          {
+                          steps_linear_time[0]['args'][1]
+                          | {
                               'sliders[0].steps': steps_linear_time,
                               'sliders[0].active': 0,
                           },
-                          steps_linear_time[0]['args'][1],
+                          steps_linear_time[0]['args'][2],
                       ],
                       label='Plasma time',
                       method='update',
@@ -850,11 +849,12 @@ def _build_slider(
                   dict(
                       args=[
                           steps_timesteps[0]['args'][0],
-                          {
+                          steps_timesteps[0]['args'][1]
+                          | {
                               'sliders[0].steps': steps_timesteps,
                               'sliders[0].active': 0,
                           },
-                          steps_timesteps[0]['args'][1],
+                          steps_timesteps[0]['args'][2],
                       ],
                       label='Simulation steps',
                       method='update',

--- a/torax/_src/plotting/plotruns_lib.py
+++ b/torax/_src/plotting/plotruns_lib.py
@@ -97,6 +97,23 @@ class PlotType(enum.Enum):
   TIME_SERIES = 2
 
 
+class SliderMode(enum.Enum):
+  """Which slider step list(s) to embed in the figure.
+
+  BOTH: Embed step lists for both linear-time and simulation-step modes,
+    with a UI toggle to switch between them. Matches legacy behavior, at the
+    cost of ~2x slider payload since both step lists are serialized.
+  LINEAR_TIME: Embed only the step list with ticks linearly spaced in time.
+    No mode toggle is shown.
+  SIMULATION_STEPS: Embed only the step list following the sim's own
+    timesteps. No mode toggle is shown.
+  """
+
+  BOTH = 'both'
+  LINEAR_TIME = 'linear_time'
+  SIMULATION_STEPS = 'simulation_steps'
+
+
 @dataclasses.dataclass
 class PlotProperties:
   """Dataclass for individual plot properties."""
@@ -139,6 +156,10 @@ class FigureProperties:
       right, top and bottom margins respectively.
     figure_title: Title of the figure. If None, a title is generated from input
       file names.
+    slider_mode: Which slider step list(s) to embed. BOTH (default) keeps
+      the legacy toggle between linear-time and simulation-step modes, at
+      the cost of duplicating step payload. Pick LINEAR_TIME or
+      SIMULATION_STEPS to embed a single step list and drop the toggle.
   """
 
   rows: int
@@ -156,6 +177,7 @@ class FigureProperties:
       default_factory=lambda: dict(l=40, r=40, t=80, b=40)
   )
   figure_title: str | None = None
+  slider_mode: SliderMode = SliderMode.BOTH
 
   def __post_init__(self):
     if len(self.axes) > self.rows * self.cols:
@@ -801,11 +823,30 @@ def _build_slider(
   if not spatial_traces_info and not timestamp_line_info:
     return
 
-  # Increase bottom margin to create whitespace for slider and dropdown.
+  # Increase bottom margin to create whitespace for slider (and dropdown,
+  # if both modes are embedded).
   current_margin = plot_config.margin
   new_margin = dict(current_margin) if current_margin else {}
   new_margin['b'] = new_margin.get('b', 50) + 100
   fig.update_layout(margin=new_margin)
+
+  if plot_config.slider_mode != SliderMode.BOTH:
+    linear_time = plot_config.slider_mode == SliderMode.LINEAR_TIME
+    steps = _get_slider_steps(
+        data1, spatial_traces_info, timestamp_line_info, linear_time
+    )
+    fig.update_layout(
+        sliders=[{
+            'active': 0,
+            'currentvalue': {'prefix': 'Time: ', 'suffix': ' s'},
+            'steps': steps,
+            'len': 0.85,
+            'x': 0.0,
+            'y': -0.1,
+            'yanchor': 'middle',
+        }]
+    )
+    return
 
   steps_timesteps = _get_slider_steps(
       data1, spatial_traces_info, timestamp_line_info, linear_time=False

--- a/torax/_src/plotting/plotruns_lib_test.py
+++ b/torax/_src/plotting/plotruns_lib_test.py
@@ -78,6 +78,42 @@ class PlotrunsLibTest(parameterized.TestCase):
     )
 
 
+class SliderPayloadTest(absltest.TestCase):
+  """Verifies slider steps carry a minimal payload (issue #553)."""
+
+  @classmethod
+  def setUpClass(cls):
+    super().setUpClass()
+    config_path = path_utils.torax_path().joinpath(
+        'plotting', 'configs', 'default_plot_config.py'
+    )
+    plot_config = config_loader.import_module(config_path)['PLOT_CONFIG']
+    test_data_path = paths.test_data_dir() / 'test_iterhybrid_rampup.nc'
+    cls.fig = plotruns_lib.plot_run(
+        plot_config, {'Data 1': str(test_data_path)}, interactive=False
+    )
+
+  def test_steps_do_not_resend_static_x_arrays(self):
+    for step in self.fig.layout.sliders[0].steps:
+      self.assertNotIn('x', step.args[0])
+
+  def test_steps_move_timestamp_shapes_via_relayout(self):
+    shapes = self.fig.layout.shapes
+    self.assertNotEmpty(shapes)
+    for step in self.fig.layout.sliders[0].steps:
+      relayout_updates = step.args[1]
+      for idx in range(len(shapes)):
+        self.assertIn(f'shapes[{idx}].x0', relayout_updates)
+        self.assertIn(f'shapes[{idx}].x1', relayout_updates)
+
+  def test_timestamp_lines_are_shapes_not_traces(self):
+    self.assertNotIn('Current Time', [trace.name for trace in self.fig.data])
+
+  def test_mode_buttons_switch_slider_steps(self):
+    for button in self.fig.layout.updatemenus[0].buttons:
+      self.assertIn('sliders[0].steps', button.args[1])
+
+
 class FigurePropertiesTest(absltest.TestCase):
 
   def test_validation_raises_error(self):

--- a/torax/_src/plotting/plotruns_lib_test.py
+++ b/torax/_src/plotting/plotruns_lib_test.py
@@ -14,6 +14,7 @@
 
 """Unit tests for torax.plotting.plotruns_lib."""
 
+import dataclasses
 import os
 
 from absl.testing import absltest
@@ -112,6 +113,44 @@ class SliderPayloadTest(absltest.TestCase):
   def test_mode_buttons_switch_slider_steps(self):
     for button in self.fig.layout.updatemenus[0].buttons:
       self.assertIn('sliders[0].steps', button.args[1])
+
+
+class SliderModeSelectionTest(parameterized.TestCase):
+  """Verifies single-mode slider_mode drops the mode toggle (issue #553)."""
+
+  @classmethod
+  def setUpClass(cls):
+    super().setUpClass()
+    config_path = path_utils.torax_path().joinpath(
+        'plotting', 'configs', 'default_plot_config.py'
+    )
+    cls.base_plot_config = config_loader.import_module(config_path)[
+        'PLOT_CONFIG'
+    ]
+    cls.test_data_path = paths.test_data_dir() / 'test_iterhybrid_rampup.nc'
+
+  @parameterized.parameters(
+      plotruns_lib.SliderMode.LINEAR_TIME,
+      plotruns_lib.SliderMode.SIMULATION_STEPS,
+  )
+  def test_single_mode_drops_toggle_and_shrinks_payload(self, slider_mode):
+    both_config = dataclasses.replace(
+        self.base_plot_config, slider_mode=plotruns_lib.SliderMode.BOTH
+    )
+    single_config = dataclasses.replace(
+        self.base_plot_config, slider_mode=slider_mode
+    )
+    fig_both = plotruns_lib.plot_run(
+        both_config, {'Data 1': str(self.test_data_path)}, interactive=False
+    )
+    fig_single = plotruns_lib.plot_run(
+        single_config, {'Data 1': str(self.test_data_path)}, interactive=False
+    )
+
+    self.assertNotEmpty(fig_both.layout.updatemenus)
+    self.assertEmpty(fig_single.layout.updatemenus)
+    self.assertLen(fig_single.layout.sliders, 1)
+    self.assertLess(len(fig_single.to_json()), len(fig_both.to_json()))
 
 
 class FigurePropertiesTest(absltest.TestCase):

--- a/torax/plotting/plotruns.py
+++ b/torax/plotting/plotruns.py
@@ -18,6 +18,8 @@ Includes a time slider. Reads output files with xarray data or legacy h5 data.
 
 Plots are configured by a plot_config module.
 """
+import dataclasses
+
 from absl import app
 from absl import logging
 from absl.flags import argparse_flags
@@ -44,6 +46,17 @@ def parse_flags(_):
       default='plotting/configs/default_plot_config.py',
       help='Name of the plot config module.',
   )
+  parser.add_argument(
+      '--slider_mode',
+      default=None,
+      choices=[mode.value for mode in plotruns_lib.SliderMode],
+      help=(
+          'Which slider step list(s) to embed in the figure. Overrides '
+          'plot_config.slider_mode. "both" keeps the legacy mode toggle at '
+          'the cost of ~2x slider payload; "linear_time" or '
+          '"simulation_steps" embeds a single step list.'
+      ),
+  )
   return parser.parse_args()
 
 
@@ -58,6 +71,10 @@ def main(args):
         'Error loading plot config: %s: %s', plot_config_module_path, e
     )
     raise
+  if args.slider_mode is not None:
+    plot_config = dataclasses.replace(
+        plot_config, slider_mode=plotruns_lib.SliderMode(args.slider_mode)
+    )
   outfiles = {
       f'Data {i + 1}': f for i, f in enumerate(args.outfile)
   }


### PR DESCRIPTION
Second, isolated speedup for #553 — stacked on #2285 (static-x/vline dedup). This branch is based on `perf/plotly-slider-payload`, so the diff below includes that PR's commit until #2285 merges; **only the second commit ("Add config/CLI option...") is new here** — please review that commit in isolation. Will auto-retarget to `main` once #2285 lands.

## Problem

The slider mode toggle ("Plasma time" vs "Simulation steps") always builds
*both* step lists and embeds both in `updatemenus`, even though most users
only ever use one mode. That's the dominant remaining share of slider
payload after #2285.

## Fix

- New `SliderMode` enum (`BOTH`, `LINEAR_TIME`, `SIMULATION_STEPS`) on
  `FigureProperties.slider_mode`, default `BOTH` (unchanged behavior).
- New `plot_torax --slider_mode` CLI flag that overrides the config value.
- When a single mode is selected, `_build_slider` builds only that step
  list and skips the `updatemenus` toggle and its annotation entirely —
  not deduplicated, fully removed.

## Measured (rampup reference dataset)

| Mode | Figure JSON size |
|---|---|
| `BOTH` (default, unchanged) | 1.37 MB |
| `LINEAR_TIME` / `SIMULATION_STEPS` | 0.48 MB |

**-65%** when a single mode is selected, on top of #2285's static-payload
cut.

## Tests

Added `SliderModeSelectionTest` (parameterized over both single modes):
confirms `updatemenus` is empty and figure JSON shrinks vs. `BOTH`. Full
plotting suite: 238/238 passing.
