### PR TITLE
Minor plot improvements

### DIFF
--- a/torax/_src/plotting/plotruns_lib.py
+++ b/torax/_src/plotting/plotruns_lib.py
@@ -636,10 +636,11 @@ def _add_traces_and_update_axes(
     fig: go.Figure,
     plot_config: FigureProperties,
     named_datasets: Mapping[str, PlotData],
-) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], dict[str, list[int]]]:
   """Adds traces to the figure and updates axes."""
   spatial_traces_info = []
   timestamp_line_info = []
+  dataset_trace_indices = {ds_name: [] for ds_name in named_datasets}
   trace_count = 0
   datasets = list(named_datasets.values())
 
@@ -691,6 +692,7 @@ def _add_traces_and_update_axes(
             row=row,
             col=col,
         )
+        dataset_trace_indices[ds_name].append(trace_count)
         trace_count += 1
 
     # Add vertical line to denote current slider time for time series plots
@@ -741,7 +743,7 @@ def _add_traces_and_update_axes(
         range=(ylow, yhigh),
     )
 
-  return spatial_traces_info, timestamp_line_info
+  return spatial_traces_info, timestamp_line_info, dataset_trace_indices
 
 
 def _get_slider_steps(
@@ -829,7 +831,7 @@ def _build_slider(
   fig.update_layout(sliders=[slider_linear_time])
 
   fig.update_layout(
-      updatemenus=[
+      updatemenus=list(fig.layout.updatemenus) + [
           dict(
               type='buttons',
               direction='right',
@@ -885,6 +887,18 @@ def _build_slider(
   )
 
 
+_LEGEND_X: Final[float] = 1.02
+# Rough estimate of the "Legend" annotation's rendered width, as a fraction
+# of figure width. Plotly cannot report the actual value at figure-build
+# time.
+_LEGEND_LABEL_WIDTH_ESTIMATE: Final[float] = 0.04
+# The legend's top edge is shunted down from the plot's top edge (y=1) to
+# leave headroom above it for the "Legend" label and run-visibility
+# dropdown, which sit centered in that headroom at `_CONTROLS_ROW_Y`.
+_LEGEND_Y: Final[float] = 0.95
+_CONTROLS_ROW_Y: Final[float] = 1.0
+
+
 def _update_global_layout(
     fig: go.Figure,
     plot_config: FigureProperties,
@@ -902,6 +916,10 @@ def _update_global_layout(
       'legend': dict(
           tracegroupgap=plot_config.legend_spacing,
           groupclick='toggleitem',
+          x=_LEGEND_X,
+          xanchor='left',
+          y=_LEGEND_Y,
+          yanchor='top',
       ),
       'font': dict(family=plot_config.font_family),
   }
@@ -916,6 +934,105 @@ def _update_global_layout(
       font=dict(
           family=plot_config.font_family, size=plot_config.subplot_title_size
       )
+  )
+
+
+def _run_combinations(names: Sequence[str]) -> list[tuple[str, ...]]:
+  """Lists the run subsets to offer in the visibility dropdown.
+
+  For up to 5 runs, every non-empty combination is offered (so any subset of
+  runs can be selected). Beyond that the combinations would explode
+  (2**n - 1 options), so only "all runs" and each run in isolation are
+  offered.
+  """
+  if len(names) > 5:
+    return [tuple(names)] + [(name,) for name in names]
+  return [
+      combo
+      for size in range(len(names), 0, -1)
+      for combo in itertools.combinations(names, size)
+  ]
+
+
+def _build_run_visibility_dropdown(
+    fig: go.Figure,
+    plot_config: FigureProperties,
+    dataset_trace_indices: Mapping[str, list[int]],
+) -> None:
+  """Adds a dropdown to select which runs' traces are shown.
+
+  Each option is a precomputed combination of runs (e.g. "All", a single run,
+  or a "+"-joined pair) that is applied in full on click.
+
+  The dropdown is placed above the legend (which is top-anchored at y=1).
+
+  Args:
+    fig: The figure to add the dropdown to.
+    plot_config: Configuration for the figure layout and subplots.
+    dataset_trace_indices: A mapping ``{dataset_label: trace_indices}`` giving
+      the indices in ``fig.data`` of all traces belonging to each run.
+  """
+  names = list(dataset_trace_indices.keys())
+  if len(names) < 2:
+    return
+
+  all_indices = sorted(
+      idx for indices in dataset_trace_indices.values() for idx in indices
+  )
+
+  options = []
+  for combo in _run_combinations(names):
+    visible_indices = {
+        idx for name in combo for idx in dataset_trace_indices[name]
+    }
+    visibility = [
+        True if idx in visible_indices else 'legendonly'
+        for idx in all_indices
+    ]
+    label = 'All' if len(combo) == len(names) else ' + '.join(combo)
+    options.append(
+        dict(
+            label=label,
+            method='restyle',
+            args=[{'visible': visibility}, all_indices],
+        )
+    )
+
+  # "Legend" is left-aligned with the legend's left edge, and the dropdown's
+  # left edge is placed immediately after the "Legend" label's right edge.
+  # Plotly cannot report the label's actual rendered width at figure-build
+  # time, so `_LEGEND_LABEL_WIDTH_ESTIMATE` is a rough estimate that may need
+  # adjustment. The two elements share the same y and use yanchor='middle',
+  # so they are exactly vertically centered with respect to each other.
+  dropdown_x = _LEGEND_X + _LEGEND_LABEL_WIDTH_ESTIMATE
+  label_y = _CONTROLS_ROW_Y
+  fig.add_annotation(
+      text='Legend',
+      x=_LEGEND_X,
+      y=label_y,
+      xref='paper',
+      yref='paper',
+      showarrow=False,
+      xanchor='left',
+      yanchor='middle',
+      font=dict(
+          family=plot_config.font_family, size=plot_config.subplot_title_size
+      ),
+  )
+  fig.update_layout(
+      updatemenus=list(fig.layout.updatemenus) + [
+          dict(
+              type='dropdown',
+              direction='down',
+              x=dropdown_x,
+              xanchor='left',
+              y=label_y,
+              yanchor='middle',
+              showactive=True,
+              active=0,
+              buttons=options,
+          )
+      ]
   )
 
 
@@ -937,13 +1054,14 @@ def create_plotly_figure(
   """
   fig = _setup_subplots(plot_config)
 
-  spatial_traces_info, timestamp_line_info = _add_traces_and_update_axes(
-      fig, plot_config, datasets
+  spatial_traces_info, timestamp_line_info, dataset_trace_indices = (
+      _add_traces_and_update_axes(fig, plot_config, datasets)
   )
 
   # Use the first dataset's time as the master clock for the slider.
   first_dataset = next(iter(datasets.values()))
   _update_global_layout(fig, plot_config, title)
+  _build_run_visibility_dropdown(fig, plot_config, dataset_trace_indices)
   _build_slider(
       fig, first_dataset, spatial_traces_info, timestamp_line_info, plot_config
   )

--- a/torax/_src/plotting/plotruns_lib.py
+++ b/torax/_src/plotting/plotruns_lib.py
@@ -899,7 +899,10 @@ def _update_global_layout(
       },
       'margin': plot_config.margin,
       'showlegend': True,
-      'legend': dict(tracegroupgap=plot_config.legend_spacing),
+      'legend': dict(
+          tracegroupgap=plot_config.legend_spacing,
+          groupclick='toggleitem',
+      ),
       'font': dict(family=plot_config.font_family),
   }
 

--- a/torax/plotting/configs/default_plot_config.py
+++ b/torax/plotting/configs/default_plot_config.py
@@ -24,8 +24,8 @@ PLOT_CONFIG = plotruns_lib.FigureProperties(
         # volatile nature of the data. Do not include first timepoint since
         # chi is defined as zero there and may unduly affect ylim.
         plotruns_lib.PlotProperties(
-            attrs=('T_i', 'T_e'),
-            labels=(r'$T_\mathrm{i}$', r'$T_\mathrm{e}$'),
+            attrs=('T_e', 'T_i'),
+            labels=(r'$T_\mathrm{e}$', r'$T_\mathrm{i}$'),
             ylabel='Temperature [keV]',
         ),
         plotruns_lib.PlotProperties(
@@ -35,12 +35,12 @@ PLOT_CONFIG = plotruns_lib.FigureProperties(
         ),
         plotruns_lib.PlotProperties(
             attrs=(
-                'chi_total_i',
                 'chi_total_e',
+                'chi_total_i',
             ),
             labels=(
-                r'$\chi_\mathrm{i}$',
                 r'$\chi_\mathrm{e}$',
+                r'$\chi_\mathrm{i}$',
             ),
             ylabel=r'Heat conductivity $[m^2/s]$',
             upper_percentile=98.0,

--- a/torax/plotting/configs/simple_plot_config.py
+++ b/torax/plotting/configs/simple_plot_config.py
@@ -21,8 +21,8 @@ PLOT_CONFIG = plotruns_lib.FigureProperties(
     cols=3,
     axes=(
         plotruns_lib.PlotProperties(
-            attrs=('T_i', 'T_e'),
-            labels=(r'$T_i$', r'$T_e$'),
+            attrs=('T_e', 'T_i'),
+            labels=(r'$T_e$', r'$T_i$'),
             ylabel='Temperature [keV]',
         ),
         plotruns_lib.PlotProperties(
@@ -31,8 +31,8 @@ PLOT_CONFIG = plotruns_lib.FigureProperties(
             ylabel=r'Electron density $[10^{20}~m^{-3}]$',
         ),
         plotruns_lib.PlotProperties(
-            attrs=('chi_turb_i', 'chi_turb_e'),
-            labels=(r'$\chi_i$', r'$\chi_e$'),
+            attrs=('chi_turb_e', 'chi_turb_i'),
+            labels=(r'$\chi_e$', r'$\chi_i$'),
             ylabel=r'Heat conductivity $[m^2/s]$',
             upper_percentile=98.0,  # Exclude outliers
             include_first_timepoint=False,

--- a/torax/plotting/configs/sources_plot_config.py
+++ b/torax/plotting/configs/sources_plot_config.py
@@ -24,8 +24,8 @@ PLOT_CONFIG = plotruns_lib.FigureProperties(
         # volatile nature of the data. Do not include first timepoint since
         # chi is defined as zero there and may unduly affect ylim.
         plotruns_lib.PlotProperties(
-            attrs=('T_i', 'T_e'),
-            labels=(r'$T_\mathrm{i}$', r'$T_\mathrm{e}$'),
+            attrs=('T_e', 'T_i'),
+            labels=(r'$T_\mathrm{e}$', r'$T_\mathrm{i}$'),
             ylabel='Temperature [keV]',
         ),
         plotruns_lib.PlotProperties(

--- a/torax/plotting/configs/transport_plot_config.py
+++ b/torax/plotting/configs/transport_plot_config.py
@@ -22,12 +22,12 @@ PLOT_CONFIG = plotruns_lib.FigureProperties(
     axes=(
         plotruns_lib.PlotProperties(
             attrs=(
-                'chi_turb_i',
                 'chi_turb_e',
+                'chi_turb_i',
             ),
             labels=(
-                r'$\chi_\mathrm{turb,i}$',
                 r'$\chi_\mathrm{turb,e}$',
+                r'$\chi_\mathrm{turb,i}$',
             ),
             ylabel=r'Turbulent heat conductivity $[m^2/s]$',
             upper_percentile=98.0,
@@ -54,12 +54,12 @@ PLOT_CONFIG = plotruns_lib.FigureProperties(
         ),
         plotruns_lib.PlotProperties(
             attrs=(
-                'chi_neo_i',
                 'chi_neo_e',
+                'chi_neo_i',
             ),
             labels=(
-                r'$\chi_\mathrm{neo,i}$',
                 r'$\chi_\mathrm{neo,e}$',
+                r'$\chi_\mathrm{neo,i}$',
             ),
             ylabel=r'Neoclassical heat conductivity $[m^2/s]$',
             upper_percentile=98.0,


### PR DESCRIPTION
- Order T and chi plot traces as electron-then-ion, matching density. This makes colors match across the plots.
- Add a dropdown to select which comparison runs are shown in the plot.
- Make legend double-click toggle only the clicked trace, not the whole subplot group.
