### PR TITLE
Add a pellet-aware time step calculator.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -2472,6 +2472,12 @@ implemented in TORAX.
 ``S_total`` (**time-varying-scalar** [default = 2e22])
   Total particle source in units of particles/s
 
+An external machine-learning surrogate of pellet ablation and deposition,
+HPI2-NN, can be registered as an alternative ``pellet`` model
+(``model_name: 'hpi2_nn'``) via ``torax.sources.register_source_model_config``.
+See the `HPI2-NN repository <https://github.com/DIFFER-NL/hpi2nn>`_ for
+installation and configuration.
+
 mhd
 ---
 
@@ -2692,7 +2698,7 @@ time_step_calculator
 
 ``calculator_type`` (str [default = 'chi'])
   The name of the ``time_step_calculator``, a method which calculates ``dt`` at
-  every timestep. Three methods are currently available:
+  every timestep. Four methods are currently available:
 
 * ``'fixed'``
     ``dt`` is equal to ``fixed_dt`` defined in :ref:`numerics_dataclass`.
@@ -2718,6 +2724,17 @@ time_step_calculator
      to a smaller value, rather than starting from max_dt every time. It can
      also speed up simulations where a small dt is required for a short section,
      but then a larger dt is be appropriate for the remainder of the simulation.
+
+* ``'pellet_aware'``
+    Uses a base calculator (``'chi'`` or ``'fixed'``) and additionally aligns
+    time steps with pellet trigger times and ablation windows, so that a step
+    lands exactly on each pellet and the ablation window is resolved as a single
+    step. It is generic over pellet sources: it reads ``trigger_times`` /
+    ``frequency`` and ``ablation_time`` from the configured pellet source's
+    runtime parameters, and if the source exposes it, a model predicted ablation
+    window. Intended for use with the HPI2-NN pellet model (see the ``pellet``
+    source above and the `HPI2-NN repository
+    <https://github.com/DIFFER-NL/hpi2nn>`_).
 
 ``tolerance`` (float [default = 1e-7])
   The tolerance within the final time for which the simulation will be

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -2458,8 +2458,9 @@ Ohmic power.
 pellet
 ^^^^^^
 
-Time-dependent Gaussian pellet source. No first-principle-based model is yet
-implemented in TORAX.
+Time-dependent Gaussian pellet source by default. A model of pellet ablation
+and deposition can also be registered as an alternative ``pellet`` model (see
+below).
 
 ``mode`` (str [default = 'model'])
 
@@ -2726,19 +2727,46 @@ time_step_calculator
      but then a larger dt is be appropriate for the remainder of the simulation.
 
 * ``'pellet_aware'``
-    Uses a base calculator (``'chi'`` or ``'fixed'``) and additionally aligns
-    time steps with pellet trigger times and ablation windows, so that a step
-    lands exactly on each pellet and the ablation window is resolved as a single
-    step. It is generic over pellet sources: it reads ``trigger_times`` /
-    ``frequency`` and ``ablation_time`` from the configured pellet source's
-    runtime parameters, and if the source exposes it, a model predicted ablation
-    window. Intended for use with the HPI2-NN pellet model (see the ``pellet``
-    source above and the `HPI2-NN repository
+    Uses a configurable base calculator (see ``base_calculator`` below) and
+    additionally aligns time steps with pellet trigger times and ablation
+    windows, so that a step lands exactly on each pellet and the ablation window
+    is resolved as a single step. It is generic over pellet sources: it reads
+    ``trigger_times`` / ``frequency`` and ``ablation_time`` from the configured 
+    pellet source's runtime parameters and if the source exposes it, a model 
+    predicted ablation window. Intended for use with the HPI2-NN pellet model 
+    (see the ``pellet`` source above and the `HPI2-NN repository
     <https://github.com/DIFFER-NL/hpi2nn>`_).
+
+    In the ``frequency`` mode the pellet source may toggle injection on and off
+    over time. Because floating point means a step never lands exactly on a
+    period boundary, such a toggle should switch on a small margin before the
+    intended pellet time, otherwise the pellet at that boundary may be skipped.
 
 ``tolerance`` (float [default = 1e-7])
   The tolerance within the final time for which the simulation will be
   considered done.
+
+The following attributes only apply to the ``'pellet_aware'`` calculator:
+
+``base_calculator`` (dict [default = None])
+  Configuration of the base time step calculator used away from pellet events,
+  for example ``{'calculator_type': 'chi'}`` or ``{'calculator_type':
+  'fixed'}``. It cannot itself be ``'pellet_aware'``. If None, the ``'chi'``
+  calculator is used.
+
+``trigger_tolerance`` (float [default = 1e-8])
+  Time tolerance for deciding whether the current time is at a pellet trigger.
+  The pellet source's own ``trigger_tolerance`` is used instead when it exposes
+  one, so that the step alignment and the source's deposition agree on when a
+  pellet fires.
+
+``window_after_pellet`` (float [default = 0.0])
+  Duration of the window after a pellet trigger during which ``dt_after_pellet``
+  is used. Not used by default.
+
+``dt_after_pellet`` (float [default = None])
+  Time step used during the window after a pellet trigger. If None, the base
+  calculator's step is used. Not used by default.
 
 neoclassical
 ------------

--- a/docs/physics_models.rst
+++ b/docs/physics_models.rst
@@ -651,7 +651,10 @@ built-in formula-based particle sources for the :math:`n_e` equation:
   - **Pellet Injection:** A Gaussian function approximates the deposition of
     particles from pellets injected into the plasma core. The time-dependent
     configuration parameter feature allows either a continuous approximation or
-    discrete pellets to be modelled.
+    discrete pellets to be modelled. An external machine-learning surrogate of
+    pellet ablation and deposition, `HPI2-NN
+    <https://github.com/DIFFER-NL/hpi2nn>`_, is also available as an alternative
+    model of the pellet source. See its repository for details.
 
   - **Generic particle source:**  An additional Gaussian function which can
     be configured to model arbitrary particle sources, e.g. to mock-up an NBI

--- a/torax/_src/time_step_calculator/pellet_aware_time_step_calculator.py
+++ b/torax/_src/time_step_calculator/pellet_aware_time_step_calculator.py
@@ -128,8 +128,12 @@ class PelletAwareTimeStepCalculator(time_step_calculator.TimeStepCalculator):
       # frequency is not None here (guaranteed by the check above).
       assert frequency is not None
       frequency_t_start = getattr(pellet_params, 'frequency_t_start', 0.0)
+      # Whether the periodic injector is on at t. Defaults to on, so a source
+      # that does not expose it keeps firing at every period.
+      injection_enabled = getattr(pellet_params, 'injection_enabled', True)
       dt_trigger, dt_after_trigger, at_trigger = self._dt_for_frequency(
-          t, dt_standard, frequency, frequency_t_start, ablation_window, tol
+          t, dt_standard, frequency, frequency_t_start, injection_enabled,
+          ablation_window, tol,
       )
 
     dt = jnp.minimum(dt_standard, jnp.minimum(dt_trigger, dt_after_trigger))
@@ -190,10 +194,15 @@ class PelletAwareTimeStepCalculator(time_step_calculator.TimeStepCalculator):
       dt_standard: jax.Array,
       frequency: jax.Array,
       frequency_t_start: float | jax.Array,
+      injection_enabled: bool | jax.Array,
       ablation_window: jax.Array,
       tol: jax.Array,
   ) -> tuple[jax.Array, jax.Array, jax.Array]:
     """Aligns dt with a periodic pellet injection frequency.
+
+    The frequency is assumed strictly positive (validated by the pellet source
+    config). injection_enabled toggles the injector on or off. When off, no
+    pellet fires and the base time step is used.
 
     Returns:
       (dt_trigger, dt_after_trigger, at_trigger).
@@ -202,30 +211,31 @@ class PelletAwareTimeStepCalculator(time_step_calculator.TimeStepCalculator):
     inf = jnp.asarray(jnp.inf, dtype=dtype)
     frequency = jnp.asarray(frequency, dtype=dtype)
     frequency_t_start = jnp.asarray(frequency_t_start, dtype=dtype)
-    positive_frequency = frequency > 0.0
-    safe_frequency = jnp.where(
-        positive_frequency, frequency, jnp.asarray(1.0, dtype=dtype)
-    )
-    period = 1.0 / safe_frequency
+    injection_enabled = jnp.asarray(injection_enabled, dtype=bool)
+    period = 1.0 / frequency
     # Phase measured from frequency_t_start (consistent with the source).
-    phase = jnp.mod(t - frequency_t_start + tol, period)
+    phase = jnp.mod(t - frequency_t_start, period)
     # Float rounding can leave phase just below period instead of wrapping
     # to 0 at a pellet time.
     phase = jnp.where(period - phase < tol, jnp.asarray(0.0, dtype=dtype), phase)
     delta_to_next_period = period - phase
-    active = jnp.logical_and(positive_frequency, t > frequency_t_start + tol)
     # A single step covers the whole ablation window, so we only need to detect
     # the firing instant (phase wrapped to 0, the same test the source should use).
-    at_trigger = jnp.logical_and(active, phase <= tol)
+    # A pellet fires when the step lands within tol of a period boundary.
+    # Floating point means the step never lands exactly on the boundary, so a
+    # time varying injection_enabled that switches on exactly at a pellet's time
+    # can still read "off" at the firing instant. Turn it on a small margin
+    # before the intended pellet time.
+    at_trigger = jnp.logical_and(injection_enabled, phase <= tol)
     dt_trigger_value = jnp.where(at_trigger, ablation_window, delta_to_next_period)
-    dt_trigger = jnp.where(active, dt_trigger_value, inf)
+    dt_trigger = jnp.where(injection_enabled, dt_trigger_value, inf)
 
     dt_after_trigger = dt_standard
     if self._dt_after_pellet is not None:
       dt_after_pellet = jnp.asarray(self._dt_after_pellet, dtype=dtype)
       window_after_pellet = jnp.asarray(self._window_after_pellet, dtype=dtype)
       in_post_pellet = jnp.logical_and(
-          active,
+          injection_enabled,
           jnp.logical_and(
               jnp.logical_and(phase > tol, jnp.logical_not(at_trigger)),
               phase < window_after_pellet - tol,

--- a/torax/_src/time_step_calculator/pellet_aware_time_step_calculator.py
+++ b/torax/_src/time_step_calculator/pellet_aware_time_step_calculator.py
@@ -1,0 +1,297 @@
+# Copyright 2024 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Time step calculator that aligns steps with pellet trigger windows."""
+
+import jax
+from jax import numpy as jnp
+from torax._src.config import runtime_params as runtime_params_lib
+from torax._src.orchestration import sim_state as sim_state_lib
+from torax._src.time_step_calculator import chi_time_step_calculator
+from torax._src.time_step_calculator import fixed_time_step_calculator
+from torax._src.time_step_calculator import time_step_calculator
+
+
+class PelletAwareTimeStepCalculator(time_step_calculator.TimeStepCalculator):
+  """TimeStepCalculator that resolves pellet trigger and ablation windows.
+
+  The pellet_aware time step calculator ensures that time steps are aligned with
+  pellet trigger times and ablation windows. 
+
+  It checks the current simulation time against the pellet trigger times 
+  and ablation duration, and adjusts the time step to ensure that steps 
+  do not skip over these events. 
+  
+  Arguments:
+    base_calculator_type: The type of the base time step calculator to use for
+      non-pellet-alignment purposes. Must be 'chi' or 'fixed'.
+    trigger_tolerance: The time tolerance for determining if the current time is
+      at a pellet trigger or ablation boundary.
+    pellet_source_name: The name of the pellet source in the runtime parameters.
+      Defaults to 'pellet'. The calculator is generic: it works with any pellet
+      source whose runtime parameters expose 'trigger_times'/'frequency' and
+      'ablation_time'. A source may additionally expose a model-predicted
+      ablation window via a 'use_model_ablation_time' flag and an
+    'ablation_step(geo, core_profiles)' method.
+    window_after_pellet: The duration of the window after a pellet trigger during
+      which the time step is adjusted. The duration of the first time step will always
+      be equal to the ablation time, the other will be equal to dt_after_pellet.
+      Not used by default.
+    dt_after_pellet: The time step to use during the window after a pellet trigger.
+      If None, the base calculator's time step is used. Not used by default.
+
+    Returns:
+      dt: Scalar time step duration.  
+  """
+
+  def __init__(
+      self,
+      base_calculator_type: str = 'chi',
+      trigger_tolerance: float = 1e-8,
+      pellet_source_name: str = 'pellet',
+      window_after_pellet: float = 0.0,
+      dt_after_pellet: float | None = None,
+  ):
+    self._base_calculator_type = base_calculator_type
+    self._trigger_tolerance = float(trigger_tolerance)
+    self._pellet_source_name = pellet_source_name
+    self._window_after_pellet = float(window_after_pellet)
+    self._dt_after_pellet = (
+        float(dt_after_pellet) if dt_after_pellet is not None else None
+    )
+    if base_calculator_type == 'chi':
+      self._base_calculator = chi_time_step_calculator.ChiTimeStepCalculator()
+    elif base_calculator_type == 'fixed':
+      self._base_calculator = (
+          fixed_time_step_calculator.FixedTimeStepCalculator()
+      )
+    else:
+      raise ValueError(
+          'base_calculator must be "chi" or "fixed" '
+      )
+
+  def _next_dt(
+      self,
+      runtime_params: runtime_params_lib.RuntimeParams,
+      sim_state: sim_state_lib.SimState,
+  ) -> jax.Array:
+    """Returns a dt aligned with pellet trigger and ablation windows."""
+    dt_standard = self._base_calculator._next_dt(runtime_params, sim_state)
+    dt_standard = jnp.asarray(dt_standard)
+    dtype = dt_standard.dtype
+
+    t = sim_state.t
+    pellet_params = runtime_params.sources.get(self._pellet_source_name)
+    if pellet_params is None:
+      return dt_standard
+
+    trigger_times = getattr(pellet_params, 'trigger_times', None)
+    frequency = getattr(pellet_params, 'frequency', None)
+    ablation_time = getattr(pellet_params, 'ablation_time', None)
+    if ablation_time is None:
+        return dt_standard
+
+    t = jnp.asarray(t, dtype=dtype)
+    tol = jnp.asarray(self._trigger_tolerance, dtype=dtype)
+    ablation_time = jnp.asarray(ablation_time, dtype=dtype)
+    inf = jnp.asarray(jnp.inf, dtype=dtype)
+    window_after_pellet = jnp.asarray(self._window_after_pellet, dtype=dtype)
+
+    in_ablation = jnp.asarray(False)
+    ablation_remaining = inf
+    dt_trigger = inf
+    next_trigger = inf
+    dt_after_trigger = inf
+    at_trigger = jnp.asarray(False)
+    model_ablation_time = inf
+
+    # A pellet source that predicts its own ablation time exposes a
+    # 'use_model_ablation_time' flag and an 'ablation_step(geo, core_profiles)'
+    # method returning (at_trigger, ablation_time).
+    ablation_step_fn = getattr(pellet_params, 'ablation_step', None)
+    use_model_ablation = bool(
+        getattr(pellet_params, 'use_model_ablation_time', False)
+    ) and callable(ablation_step_fn)
+    if use_model_ablation:
+      at_trigger, model_ablation_time = ablation_step_fn(
+          sim_state.geometry, sim_state.core_profiles
+      )
+      at_trigger = jnp.asarray(at_trigger)
+      model_ablation_time = jnp.asarray(model_ablation_time, dtype=dtype)
+
+    if trigger_times is not None:
+      neg_inf = jnp.asarray(-jnp.inf, dtype=dtype)
+      last_trigger = neg_inf
+
+      for trigger in trigger_times:
+        trigger = jnp.asarray(trigger, dtype=dtype)
+        is_next_trigger = trigger > t - tol
+        next_trigger = jnp.where(
+          is_next_trigger,
+          jnp.minimum(next_trigger, trigger),
+          next_trigger,
+        )
+        is_past = trigger <= t + tol
+        last_trigger = jnp.where(
+          is_past,
+          jnp.maximum(last_trigger, trigger),
+          last_trigger,
+        )
+
+      delta_to_next_trigger = next_trigger - t
+      if use_model_ablation:
+        # One step at the trigger covering the model-predicted ablation time.
+        # ablation_remaining is only read when in_ablation.
+        in_ablation = at_trigger
+        ablation_remaining = model_ablation_time
+        dt_trigger = jnp.where(
+            at_trigger, model_ablation_time, delta_to_next_trigger
+        )
+      else:
+        end = next_trigger + ablation_time
+        in_ablation = jnp.logical_and(
+          t >= next_trigger - tol,
+          t < end - tol,
+        )
+        ablation_remaining = jnp.where(
+            in_ablation,
+            end - t,
+            ablation_remaining,
+        )
+        dt_trigger = jnp.where(
+            in_ablation,
+            ablation_remaining,
+            delta_to_next_trigger,
+        )
+      if self._dt_after_pellet is not None:
+        dt_after_pellet = jnp.asarray(self._dt_after_pellet, dtype=dtype)
+        has_past_trigger = jnp.isfinite(last_trigger)
+        post_window_end = last_trigger + window_after_pellet
+        in_post_pellet = jnp.logical_and(
+            has_past_trigger,
+            jnp.logical_and(
+                jnp.logical_and(
+                    t > last_trigger + tol, jnp.logical_not(in_ablation)
+                ),
+                t < post_window_end - tol,
+            ),
+        )
+        post_remaining = post_window_end - t
+        dt_after_trigger = jnp.where(
+            in_post_pellet,
+            jnp.minimum(dt_after_pellet, post_remaining),
+            inf,
+        )
+
+
+    elif frequency is not None:
+      frequency = jnp.asarray(frequency, dtype=dtype)
+      frequency_t_start = jnp.asarray(
+          getattr(pellet_params, 'frequency_t_start', 0.0), dtype=dtype
+      )
+      positive_frequency = frequency > 0.0
+      safe_frequency = jnp.where(
+          positive_frequency, frequency, jnp.asarray(1.0, dtype=dtype)
+      )
+      period = 1.0 / safe_frequency
+      # Phase measured from frequency_t_start (consistent with the source).
+      phase = jnp.mod(t - frequency_t_start + tol, period)
+      # Float rounding can leave phase just below period instead of wrapping
+      # to 0 at a pellet time.
+      phase = jnp.where(
+          period - phase < tol, jnp.asarray(0.0, dtype=dtype), phase
+      )
+      delta_to_next_period = period - phase
+
+      after_start = t > frequency_t_start + tol
+      if use_model_ablation:
+        in_ablation = at_trigger
+        ablation_remaining = model_ablation_time
+        dt_trigger_value = jnp.where(
+            at_trigger, model_ablation_time, delta_to_next_period
+        )
+      else:
+        in_ablation = jnp.logical_and(
+            jnp.logical_and(positive_frequency, after_start),
+            phase < ablation_time - tol,
+        )
+        ablation_remaining = jnp.where(
+            in_ablation,
+            ablation_time - phase,
+            ablation_remaining,
+        )
+        dt_trigger_value = jnp.where(
+            in_ablation,
+            ablation_remaining,
+            delta_to_next_period,
+        )
+      dt_trigger = jnp.where(
+          jnp.logical_and(positive_frequency, after_start),
+          dt_trigger_value,
+          dt_trigger,
+      )
+      if self._dt_after_pellet is not None:
+        dt_after_pellet = jnp.asarray(self._dt_after_pellet, dtype=dtype)
+        in_post_pellet_freq = jnp.logical_and(
+            jnp.logical_and(positive_frequency, after_start),
+            jnp.logical_and(
+                jnp.logical_and(phase > tol, jnp.logical_not(in_ablation)),
+                phase < window_after_pellet - tol,
+            ),
+        )
+        post_remaining_freq = window_after_pellet - phase
+        dt_after_trigger = jnp.where(
+            in_post_pellet_freq,
+            jnp.minimum(dt_after_pellet, post_remaining_freq),
+            inf,
+        )
+
+    dt = jnp.minimum(dt_standard, jnp.minimum(dt_trigger, dt_after_trigger))
+    # During ablation, never split the window: even if dt_standard is smaller.
+    dt = jnp.where(in_ablation, ablation_remaining, dt)
+
+    crosses_t_final = (t < runtime_params.numerics.t_final) * (
+        t + dt > runtime_params.numerics.t_final
+    )
+    dt = jax.lax.select(
+        jnp.logical_and(
+            runtime_params.numerics.exact_t_final,
+            crosses_t_final,
+        ),
+        runtime_params.numerics.t_final - t,
+        dt,
+    )
+    return dt
+
+  def __eq__(self, other) -> bool:
+    return (
+        isinstance(other, type(self))
+        and self._base_calculator_type == other._base_calculator_type
+        and self._trigger_tolerance == other._trigger_tolerance
+        and self._pellet_source_name == other._pellet_source_name
+        and self._window_after_pellet == other._window_after_pellet
+        and self._dt_after_pellet == other._dt_after_pellet
+    )
+
+  def __hash__(self) -> int:
+    return hash(
+        (
+            type(self),
+            self._base_calculator_type,
+            self._trigger_tolerance,
+            self._pellet_source_name,
+            self._window_after_pellet,
+            self._dt_after_pellet,
+        )
+    )

--- a/torax/_src/time_step_calculator/pellet_aware_time_step_calculator.py
+++ b/torax/_src/time_step_calculator/pellet_aware_time_step_calculator.py
@@ -18,8 +18,6 @@ import jax
 from jax import numpy as jnp
 from torax._src.config import runtime_params as runtime_params_lib
 from torax._src.orchestration import sim_state as sim_state_lib
-from torax._src.time_step_calculator import chi_time_step_calculator
-from torax._src.time_step_calculator import fixed_time_step_calculator
 from torax._src.time_step_calculator import time_step_calculator
 
 
@@ -33,17 +31,17 @@ class PelletAwareTimeStepCalculator(time_step_calculator.TimeStepCalculator):
   and ablation duration, and adjusts the time step to ensure that steps 
   do not skip over these events. 
   
+  The calculator is generic over pellet sources: it reads the 'pellet' source's
+  runtime parameters, expecting 'trigger_times' or 'frequency' and
+  'ablation_time', and optionally a model-predicted ablation window exposed via a
+  'use_model_ablation_time' flag and an 'ablation_step(geo, core_profiles)'
+  method.
+
   Arguments:
-    base_calculator_type: The type of the base time step calculator to use for
-      non-pellet-alignment purposes. Must be 'chi' or 'fixed'.
+    base_calculator: The base time step calculator used away from pellet events
+      (for example a chi or fixed calculator).
     trigger_tolerance: The time tolerance for determining if the current time is
       at a pellet trigger or ablation boundary.
-    pellet_source_name: The name of the pellet source in the runtime parameters.
-      Defaults to 'pellet'. The calculator is generic: it works with any pellet
-      source whose runtime parameters expose 'trigger_times'/'frequency' and
-      'ablation_time'. A source may additionally expose a model-predicted
-      ablation window via a 'use_model_ablation_time' flag and an
-    'ablation_step(geo, core_profiles)' method.
     window_after_pellet: The duration of the window after a pellet trigger during
       which the time step is adjusted. The duration of the first time step will always
       be equal to the ablation time, the other will be equal to dt_after_pellet.
@@ -57,29 +55,17 @@ class PelletAwareTimeStepCalculator(time_step_calculator.TimeStepCalculator):
 
   def __init__(
       self,
-      base_calculator_type: str = 'chi',
+      base_calculator: time_step_calculator.TimeStepCalculator,
       trigger_tolerance: float = 1e-8,
-      pellet_source_name: str = 'pellet',
       window_after_pellet: float = 0.0,
       dt_after_pellet: float | None = None,
   ):
-    self._base_calculator_type = base_calculator_type
+    self._base_calculator = base_calculator
     self._trigger_tolerance = float(trigger_tolerance)
-    self._pellet_source_name = pellet_source_name
     self._window_after_pellet = float(window_after_pellet)
     self._dt_after_pellet = (
         float(dt_after_pellet) if dt_after_pellet is not None else None
     )
-    if base_calculator_type == 'chi':
-      self._base_calculator = chi_time_step_calculator.ChiTimeStepCalculator()
-    elif base_calculator_type == 'fixed':
-      self._base_calculator = (
-          fixed_time_step_calculator.FixedTimeStepCalculator()
-      )
-    else:
-      raise ValueError(
-          'base_calculator must be "chi" or "fixed" '
-      )
 
   def _next_dt(
       self,
@@ -92,7 +78,7 @@ class PelletAwareTimeStepCalculator(time_step_calculator.TimeStepCalculator):
     dtype = dt_standard.dtype
 
     t = sim_state.t
-    pellet_params = runtime_params.sources.get(self._pellet_source_name)
+    pellet_params = runtime_params.sources.get('pellet')
     if pellet_params is None:
       return dt_standard
 
@@ -277,9 +263,8 @@ class PelletAwareTimeStepCalculator(time_step_calculator.TimeStepCalculator):
   def __eq__(self, other) -> bool:
     return (
         isinstance(other, type(self))
-        and self._base_calculator_type == other._base_calculator_type
+        and self._base_calculator == other._base_calculator
         and self._trigger_tolerance == other._trigger_tolerance
-        and self._pellet_source_name == other._pellet_source_name
         and self._window_after_pellet == other._window_after_pellet
         and self._dt_after_pellet == other._dt_after_pellet
     )
@@ -288,9 +273,8 @@ class PelletAwareTimeStepCalculator(time_step_calculator.TimeStepCalculator):
     return hash(
         (
             type(self),
-            self._base_calculator_type,
+            self._base_calculator,
             self._trigger_tolerance,
-            self._pellet_source_name,
             self._window_after_pellet,
             self._dt_after_pellet,
         )

--- a/torax/_src/time_step_calculator/pellet_aware_time_step_calculator.py
+++ b/torax/_src/time_step_calculator/pellet_aware_time_step_calculator.py
@@ -14,6 +14,8 @@
 
 """Time step calculator that aligns steps with pellet trigger windows."""
 
+from typing import Any
+
 import jax
 from jax import numpy as jnp
 from torax._src.config import runtime_params as runtime_params_lib
@@ -25,12 +27,12 @@ class PelletAwareTimeStepCalculator(time_step_calculator.TimeStepCalculator):
   """TimeStepCalculator that resolves pellet trigger and ablation windows.
 
   The pellet_aware time step calculator ensures that time steps are aligned with
-  pellet trigger times and ablation windows. 
+  pellet trigger times and ablation windows.
 
-  It checks the current simulation time against the pellet trigger times 
-  and ablation duration, and adjusts the time step to ensure that steps 
-  do not skip over these events. 
-  
+  It checks the current simulation time against the pellet trigger times
+  and ablation duration, and adjusts the time step to ensure that steps
+  do not skip over these events.
+
   The calculator is generic over pellet sources: it reads the 'pellet' source's
   runtime parameters, expecting 'trigger_times' or 'frequency' and
   'ablation_time', and optionally a model-predicted ablation window exposed via a
@@ -40,8 +42,10 @@ class PelletAwareTimeStepCalculator(time_step_calculator.TimeStepCalculator):
   Arguments:
     base_calculator: The base time step calculator used away from pellet events
       (for example a chi or fixed calculator).
-    trigger_tolerance: The time tolerance for determining if the current time is
-      at a pellet trigger or ablation boundary.
+    trigger_tolerance: Fallback time tolerance for deciding whether the current
+      time is at a pellet trigger. The pellet source's own 'trigger_tolerance' is
+      used instead when it exposes one, so that the step alignment and the
+      source's deposition agree on when a pellet fires.
     window_after_pellet: The duration of the window after a pellet trigger during
       which the time step is adjusted. The duration of the first time step will always
       be equal to the ablation time, the other will be equal to dt_after_pellet.
@@ -50,7 +54,7 @@ class PelletAwareTimeStepCalculator(time_step_calculator.TimeStepCalculator):
       If None, the base calculator's time step is used. Not used by default.
 
     Returns:
-      dt: Scalar time step duration.  
+      dt: Scalar time step duration.
   """
 
   def __init__(
@@ -73,192 +77,166 @@ class PelletAwareTimeStepCalculator(time_step_calculator.TimeStepCalculator):
       sim_state: sim_state_lib.SimState,
   ) -> jax.Array:
     """Returns a dt aligned with pellet trigger and ablation windows."""
-    dt_standard = self._base_calculator._next_dt(runtime_params, sim_state)
-    dt_standard = jnp.asarray(dt_standard)
+    dt_standard = jnp.asarray(
+        self._base_calculator._next_dt(runtime_params, sim_state)
+    )
     dtype = dt_standard.dtype
 
-    t = sim_state.t
+    # A compatible pellet source is guaranteed by the ToraxConfig validator.
     pellet_params = runtime_params.sources.get('pellet')
-    if pellet_params is None:
-      return dt_standard
-
     trigger_times = getattr(pellet_params, 'trigger_times', None)
     frequency = getattr(pellet_params, 'frequency', None)
-    ablation_time = getattr(pellet_params, 'ablation_time', None)
-    if ablation_time is None:
-        return dt_standard
+    if (trigger_times is None) == (frequency is None):
+      raise ValueError(
+          "The 'pellet_aware' time step calculator requires the pellet source"
+          " to configure exactly one of 'trigger_times' or 'frequency'."
+      )
 
-    t = jnp.asarray(t, dtype=dtype)
-    tol = jnp.asarray(self._trigger_tolerance, dtype=dtype)
-    ablation_time = jnp.asarray(ablation_time, dtype=dtype)
-    inf = jnp.asarray(jnp.inf, dtype=dtype)
-    window_after_pellet = jnp.asarray(self._window_after_pellet, dtype=dtype)
+    t = jnp.asarray(sim_state.t, dtype=dtype)
+    # Use the pellet source's own trigger tolerance so that the step alignment
+    # and the source's deposition agree on when a pellet fires, fall back to the
+    # configured tolerance for sources that do not expose one.
+    tol = jnp.asarray(
+        getattr(pellet_params, 'trigger_tolerance', self._trigger_tolerance),
+        dtype=dtype,
+    )
 
-    in_ablation = jnp.asarray(False)
-    ablation_remaining = inf
-    dt_trigger = inf
-    next_trigger = inf
-    dt_after_trigger = inf
-    at_trigger = jnp.asarray(False)
-    model_ablation_time = inf
-
-    # A pellet source that predicts its own ablation time exposes a
-    # 'use_model_ablation_time' flag and an 'ablation_step(geo, core_profiles)'
-    # method returning (at_trigger, ablation_time).
-    ablation_step_fn = getattr(pellet_params, 'ablation_step', None)
+    # The whole ablation is resolved as a single step landing on the trigger.
+    # A pellet source can predict it via a 'use_model_ablation_time' flag and an
+    # 'ablation_step(geo, core_profiles)' method. The model output is only valid
+    # at the firing instant, but the calculator detects the trigger itself,
+    # so only the returned duration is used. Otherwise the configured constant
+    # 'ablation_time' is used.
+    ablation_window = jnp.asarray(
+        getattr(pellet_params, 'ablation_time'), dtype=dtype
+    )
+    ablation_step_fn: Any = getattr(pellet_params, 'ablation_step', None)
     use_model_ablation = bool(
         getattr(pellet_params, 'use_model_ablation_time', False)
     ) and callable(ablation_step_fn)
     if use_model_ablation:
-      at_trigger, model_ablation_time = ablation_step_fn(
+      _, model_ablation_time = ablation_step_fn(
           sim_state.geometry, sim_state.core_profiles
       )
-      at_trigger = jnp.asarray(at_trigger)
-      model_ablation_time = jnp.asarray(model_ablation_time, dtype=dtype)
+      ablation_window = jnp.asarray(model_ablation_time, dtype=dtype)
 
     if trigger_times is not None:
-      neg_inf = jnp.asarray(-jnp.inf, dtype=dtype)
-      last_trigger = neg_inf
-
-      for trigger in trigger_times:
-        trigger = jnp.asarray(trigger, dtype=dtype)
-        is_next_trigger = trigger > t - tol
-        next_trigger = jnp.where(
-          is_next_trigger,
-          jnp.minimum(next_trigger, trigger),
-          next_trigger,
-        )
-        is_past = trigger <= t + tol
-        last_trigger = jnp.where(
-          is_past,
-          jnp.maximum(last_trigger, trigger),
-          last_trigger,
-        )
-
-      delta_to_next_trigger = next_trigger - t
-      if use_model_ablation:
-        # One step at the trigger covering the model-predicted ablation time.
-        # ablation_remaining is only read when in_ablation.
-        in_ablation = at_trigger
-        ablation_remaining = model_ablation_time
-        dt_trigger = jnp.where(
-            at_trigger, model_ablation_time, delta_to_next_trigger
-        )
-      else:
-        end = next_trigger + ablation_time
-        in_ablation = jnp.logical_and(
-          t >= next_trigger - tol,
-          t < end - tol,
-        )
-        ablation_remaining = jnp.where(
-            in_ablation,
-            end - t,
-            ablation_remaining,
-        )
-        dt_trigger = jnp.where(
-            in_ablation,
-            ablation_remaining,
-            delta_to_next_trigger,
-        )
-      if self._dt_after_pellet is not None:
-        dt_after_pellet = jnp.asarray(self._dt_after_pellet, dtype=dtype)
-        has_past_trigger = jnp.isfinite(last_trigger)
-        post_window_end = last_trigger + window_after_pellet
-        in_post_pellet = jnp.logical_and(
-            has_past_trigger,
-            jnp.logical_and(
-                jnp.logical_and(
-                    t > last_trigger + tol, jnp.logical_not(in_ablation)
-                ),
-                t < post_window_end - tol,
-            ),
-        )
-        post_remaining = post_window_end - t
-        dt_after_trigger = jnp.where(
-            in_post_pellet,
-            jnp.minimum(dt_after_pellet, post_remaining),
-            inf,
-        )
-
-
-    elif frequency is not None:
-      frequency = jnp.asarray(frequency, dtype=dtype)
-      frequency_t_start = jnp.asarray(
-          getattr(pellet_params, 'frequency_t_start', 0.0), dtype=dtype
+      dt_trigger, dt_after_trigger, at_trigger = self._dt_for_trigger_times(
+          t, dt_standard, trigger_times, ablation_window, tol
       )
-      positive_frequency = frequency > 0.0
-      safe_frequency = jnp.where(
-          positive_frequency, frequency, jnp.asarray(1.0, dtype=dtype)
+    else:
+      # frequency is not None here (guaranteed by the check above).
+      assert frequency is not None
+      frequency_t_start = getattr(pellet_params, 'frequency_t_start', 0.0)
+      dt_trigger, dt_after_trigger, at_trigger = self._dt_for_frequency(
+          t, dt_standard, frequency, frequency_t_start, ablation_window, tol
       )
-      period = 1.0 / safe_frequency
-      # Phase measured from frequency_t_start (consistent with the source).
-      phase = jnp.mod(t - frequency_t_start + tol, period)
-      # Float rounding can leave phase just below period instead of wrapping
-      # to 0 at a pellet time.
-      phase = jnp.where(
-          period - phase < tol, jnp.asarray(0.0, dtype=dtype), phase
-      )
-      delta_to_next_period = period - phase
-
-      after_start = t > frequency_t_start + tol
-      if use_model_ablation:
-        in_ablation = at_trigger
-        ablation_remaining = model_ablation_time
-        dt_trigger_value = jnp.where(
-            at_trigger, model_ablation_time, delta_to_next_period
-        )
-      else:
-        in_ablation = jnp.logical_and(
-            jnp.logical_and(positive_frequency, after_start),
-            phase < ablation_time - tol,
-        )
-        ablation_remaining = jnp.where(
-            in_ablation,
-            ablation_time - phase,
-            ablation_remaining,
-        )
-        dt_trigger_value = jnp.where(
-            in_ablation,
-            ablation_remaining,
-            delta_to_next_period,
-        )
-      dt_trigger = jnp.where(
-          jnp.logical_and(positive_frequency, after_start),
-          dt_trigger_value,
-          dt_trigger,
-      )
-      if self._dt_after_pellet is not None:
-        dt_after_pellet = jnp.asarray(self._dt_after_pellet, dtype=dtype)
-        in_post_pellet_freq = jnp.logical_and(
-            jnp.logical_and(positive_frequency, after_start),
-            jnp.logical_and(
-                jnp.logical_and(phase > tol, jnp.logical_not(in_ablation)),
-                phase < window_after_pellet - tol,
-            ),
-        )
-        post_remaining_freq = window_after_pellet - phase
-        dt_after_trigger = jnp.where(
-            in_post_pellet_freq,
-            jnp.minimum(dt_after_pellet, post_remaining_freq),
-            inf,
-        )
 
     dt = jnp.minimum(dt_standard, jnp.minimum(dt_trigger, dt_after_trigger))
-    # During ablation, never split the window: even if dt_standard is smaller.
-    dt = jnp.where(in_ablation, ablation_remaining, dt)
-
-    crosses_t_final = (t < runtime_params.numerics.t_final) * (
-        t + dt > runtime_params.numerics.t_final
-    )
-    dt = jax.lax.select(
-        jnp.logical_and(
-            runtime_params.numerics.exact_t_final,
-            crosses_t_final,
-        ),
-        runtime_params.numerics.t_final - t,
-        dt,
-    )
+    # During ablation, never split the window, even if dt_standard is smaller.
+    dt = jnp.where(at_trigger, ablation_window, dt)
     return dt
+
+  def _dt_for_trigger_times(
+      self,
+      t: jax.Array,
+      dt_standard: jax.Array,
+      trigger_times: tuple[float, ...],
+      ablation_window: jax.Array,
+      tol: jax.Array,
+  ) -> tuple[jax.Array, jax.Array, jax.Array]:
+    """Aligns dt with an explicit list of pellet trigger times.
+
+    Returns:
+      (dt_trigger, dt_after_trigger, at_trigger).
+    """
+    dtype = dt_standard.dtype
+    inf = jnp.asarray(jnp.inf, dtype=dtype)
+    triggers = jnp.asarray(trigger_times, dtype=dtype)
+    # Earliest trigger strictly after t (inf if none), and most recent trigger
+    # at or before t (-inf if none).
+    next_trigger = jnp.min(jnp.where(triggers > t - tol, triggers, inf))
+    last_trigger = jnp.max(jnp.where(triggers <= t + tol, triggers, -inf))
+    # A single step covers the whole ablation window, so we only need to detect
+    # the firing instant (should be the same test the pellet source uses to deposit).
+    at_trigger = jnp.any(jnp.abs(t - triggers) <= tol)
+    delta_to_next_trigger = next_trigger - t
+    dt_trigger = jnp.where(at_trigger, ablation_window, delta_to_next_trigger)
+
+    dt_after_trigger = dt_standard
+    if self._dt_after_pellet is not None:
+      dt_after_pellet = jnp.asarray(self._dt_after_pellet, dtype=dtype)
+      window_after_pellet = jnp.asarray(self._window_after_pellet, dtype=dtype)
+      post_window_end = last_trigger + window_after_pellet
+      in_post_pellet = jnp.logical_and(
+          jnp.isfinite(last_trigger),
+          jnp.logical_and(
+              jnp.logical_and(
+                  t > last_trigger + tol, jnp.logical_not(at_trigger)
+              ),
+              t < post_window_end - tol,
+          ),
+      )
+      dt_after_trigger = jnp.where(
+          in_post_pellet,
+          jnp.minimum(dt_after_pellet, post_window_end - t),
+          dt_standard,
+      )
+    return dt_trigger, dt_after_trigger, at_trigger
+
+  def _dt_for_frequency(
+      self,
+      t: jax.Array,
+      dt_standard: jax.Array,
+      frequency: jax.Array,
+      frequency_t_start: float | jax.Array,
+      ablation_window: jax.Array,
+      tol: jax.Array,
+  ) -> tuple[jax.Array, jax.Array, jax.Array]:
+    """Aligns dt with a periodic pellet injection frequency.
+
+    Returns:
+      (dt_trigger, dt_after_trigger, at_trigger).
+    """
+    dtype = dt_standard.dtype
+    inf = jnp.asarray(jnp.inf, dtype=dtype)
+    frequency = jnp.asarray(frequency, dtype=dtype)
+    frequency_t_start = jnp.asarray(frequency_t_start, dtype=dtype)
+    positive_frequency = frequency > 0.0
+    safe_frequency = jnp.where(
+        positive_frequency, frequency, jnp.asarray(1.0, dtype=dtype)
+    )
+    period = 1.0 / safe_frequency
+    # Phase measured from frequency_t_start (consistent with the source).
+    phase = jnp.mod(t - frequency_t_start + tol, period)
+    # Float rounding can leave phase just below period instead of wrapping
+    # to 0 at a pellet time.
+    phase = jnp.where(period - phase < tol, jnp.asarray(0.0, dtype=dtype), phase)
+    delta_to_next_period = period - phase
+    active = jnp.logical_and(positive_frequency, t > frequency_t_start + tol)
+    # A single step covers the whole ablation window, so we only need to detect
+    # the firing instant (phase wrapped to 0, the same test the source should use).
+    at_trigger = jnp.logical_and(active, phase <= tol)
+    dt_trigger_value = jnp.where(at_trigger, ablation_window, delta_to_next_period)
+    dt_trigger = jnp.where(active, dt_trigger_value, inf)
+
+    dt_after_trigger = dt_standard
+    if self._dt_after_pellet is not None:
+      dt_after_pellet = jnp.asarray(self._dt_after_pellet, dtype=dtype)
+      window_after_pellet = jnp.asarray(self._window_after_pellet, dtype=dtype)
+      in_post_pellet = jnp.logical_and(
+          active,
+          jnp.logical_and(
+              jnp.logical_and(phase > tol, jnp.logical_not(at_trigger)),
+              phase < window_after_pellet - tol,
+          ),
+      )
+      dt_after_trigger = jnp.where(
+          in_post_pellet,
+          jnp.minimum(dt_after_pellet, window_after_pellet - phase),
+          dt_standard,
+      )
+    return dt_trigger, dt_after_trigger, at_trigger
 
   def __eq__(self, other) -> bool:
     return (

--- a/torax/_src/time_step_calculator/pydantic_model.py
+++ b/torax/_src/time_step_calculator/pydantic_model.py
@@ -17,6 +17,7 @@
 import enum
 from typing import Annotated
 
+import pydantic
 from torax._src.time_step_calculator import chi_time_step_calculator
 from torax._src.time_step_calculator import fixed_time_step_calculator
 from torax._src.time_step_calculator import from_previous_time_step_calculator
@@ -24,6 +25,7 @@ from torax._src.time_step_calculator import pellet_aware_time_step_calculator
 from torax._src.time_step_calculator import runtime_params
 from torax._src.time_step_calculator import time_step_calculator
 from torax._src.torax_pydantic import torax_pydantic
+from typing_extensions import Self
 
 
 @enum.unique
@@ -35,12 +37,6 @@ class TimeStepCalculatorType(enum.Enum):
   FROM_PREVIOUS_DT = 'from_previous_dt'
   PELLET_AWARE = 'pellet_aware'
 
-@enum.unique
-class BaseTimeStepCalculatorType(enum.Enum):
-  """Types of base time step calculators wrapped by pellet-aware mode."""
-
-  CHI = 'chi'
-  FIXED = 'fixed'
 
 class TimeStepCalculator(torax_pydantic.BaseModelFrozen):
   """Config for a time step calculator.
@@ -49,21 +45,45 @@ class TimeStepCalculator(torax_pydantic.BaseModelFrozen):
     calculator_type: The type of time step calculator to use.
     tolerance: The tolerance within the final time for which the simulation will
       be considered done.
-    pellet_source_name: For the 'pellet_aware' calculator, the name of the pellet
-      source to align time steps with. Defaults to 'pellet'.
+    base_calculator: For the 'pellet_aware' calculator, the base time
+      step calculator used away from pellet events. If None, the
+      'chi' calculator is used.
+    trigger_tolerance: For the 'pellet_aware' calculator, the time tolerance for
+      deciding whether the current time coincides with a pellet trigger or an
+      ablation boundary.
+    window_after_pellet: For the 'pellet_aware' calculator, the duration of the
+      window after a pellet trigger during which dt_after_pellet is used.
+    dt_after_pellet: For the 'pellet_aware' calculator, the time step used during
+      the window after a pellet trigger. If None, the base calculator's step is
+      used.
   """
 
   calculator_type: Annotated[
       TimeStepCalculatorType, torax_pydantic.JAX_STATIC
   ] = TimeStepCalculatorType.CHI
   tolerance: float = 1e-7
-  base_calculator_type: Annotated[
-      BaseTimeStepCalculatorType, torax_pydantic.JAX_STATIC
-  ] = BaseTimeStepCalculatorType.CHI
+  base_calculator: 'TimeStepCalculator | None' = None
   trigger_tolerance: float = 1e-8
-  pellet_source_name: Annotated[str, torax_pydantic.JAX_STATIC] = 'pellet'
   window_after_pellet: float = 0.0
   dt_after_pellet: float | None = None
+
+  @pydantic.model_validator(mode='after')
+  def _validate_base_calculator(self) -> Self:
+    if self.base_calculator is not None:
+      if self.calculator_type != TimeStepCalculatorType.PELLET_AWARE:
+        raise ValueError(
+            'base_calculator is only used by the pellet_aware time step '
+            'calculator.'
+        )
+      if (
+          self.base_calculator.calculator_type
+          == TimeStepCalculatorType.PELLET_AWARE
+      ):
+        raise ValueError(
+            'The base_calculator of a pellet_aware calculator cannot itself be '
+            'pellet_aware.'
+        )
+    return self
 
   def build_runtime_params(self) -> runtime_params.RuntimeParams:
     return runtime_params.RuntimeParams(tolerance=self.tolerance)
@@ -81,10 +101,15 @@ class TimeStepCalculator(torax_pydantic.BaseModelFrozen):
             from_previous_time_step_calculator.FromPreviousTimeStepCalculator()
         )
       case TimeStepCalculatorType.PELLET_AWARE:
+        # Default the calculator to 'chi' when none is configured.
+        base_calculator_config = self.base_calculator or TimeStepCalculator()
         return pellet_aware_time_step_calculator.PelletAwareTimeStepCalculator(
-            base_calculator_type=self.base_calculator_type.value,
+            base_calculator=base_calculator_config.build_time_step_calculator(),
             trigger_tolerance=self.trigger_tolerance,
-            pellet_source_name=self.pellet_source_name,
             window_after_pellet=self.window_after_pellet,
             dt_after_pellet=self.dt_after_pellet,
         )
+
+
+# Resolve the self-referential 'base_calculator' annotation.
+TimeStepCalculator.model_rebuild()

--- a/torax/_src/time_step_calculator/pydantic_model.py
+++ b/torax/_src/time_step_calculator/pydantic_model.py
@@ -20,6 +20,7 @@ from typing import Annotated
 from torax._src.time_step_calculator import chi_time_step_calculator
 from torax._src.time_step_calculator import fixed_time_step_calculator
 from torax._src.time_step_calculator import from_previous_time_step_calculator
+from torax._src.time_step_calculator import pellet_aware_time_step_calculator
 from torax._src.time_step_calculator import runtime_params
 from torax._src.time_step_calculator import time_step_calculator
 from torax._src.torax_pydantic import torax_pydantic
@@ -32,7 +33,14 @@ class TimeStepCalculatorType(enum.Enum):
   CHI = 'chi'
   FIXED = 'fixed'
   FROM_PREVIOUS_DT = 'from_previous_dt'
+  PELLET_AWARE = 'pellet_aware'
 
+@enum.unique
+class BaseTimeStepCalculatorType(enum.Enum):
+  """Types of base time step calculators wrapped by pellet-aware mode."""
+
+  CHI = 'chi'
+  FIXED = 'fixed'
 
 class TimeStepCalculator(torax_pydantic.BaseModelFrozen):
   """Config for a time step calculator.
@@ -41,12 +49,21 @@ class TimeStepCalculator(torax_pydantic.BaseModelFrozen):
     calculator_type: The type of time step calculator to use.
     tolerance: The tolerance within the final time for which the simulation will
       be considered done.
+    pellet_source_name: For the 'pellet_aware' calculator, the name of the pellet
+      source to align time steps with. Defaults to 'pellet'.
   """
 
   calculator_type: Annotated[
       TimeStepCalculatorType, torax_pydantic.JAX_STATIC
   ] = TimeStepCalculatorType.CHI
   tolerance: float = 1e-7
+  base_calculator_type: Annotated[
+      BaseTimeStepCalculatorType, torax_pydantic.JAX_STATIC
+  ] = BaseTimeStepCalculatorType.CHI
+  trigger_tolerance: float = 1e-8
+  pellet_source_name: Annotated[str, torax_pydantic.JAX_STATIC] = 'pellet'
+  window_after_pellet: float = 0.0
+  dt_after_pellet: float | None = None
 
   def build_runtime_params(self) -> runtime_params.RuntimeParams:
     return runtime_params.RuntimeParams(tolerance=self.tolerance)
@@ -62,4 +79,12 @@ class TimeStepCalculator(torax_pydantic.BaseModelFrozen):
       case TimeStepCalculatorType.FROM_PREVIOUS_DT:
         return (
             from_previous_time_step_calculator.FromPreviousTimeStepCalculator()
+        )
+      case TimeStepCalculatorType.PELLET_AWARE:
+        return pellet_aware_time_step_calculator.PelletAwareTimeStepCalculator(
+            base_calculator_type=self.base_calculator_type.value,
+            trigger_tolerance=self.trigger_tolerance,
+            pellet_source_name=self.pellet_source_name,
+            window_after_pellet=self.window_after_pellet,
+            dt_after_pellet=self.dt_after_pellet,
         )

--- a/torax/_src/time_step_calculator/tests/pellet_aware_time_step_calculator_test.py
+++ b/torax/_src/time_step_calculator/tests/pellet_aware_time_step_calculator_test.py
@@ -1,0 +1,261 @@
+# Copyright 2024 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the pellet-aware time step calculator.
+
+The calculator only reads the current time and the 'pellet' source runtime
+parameters, so '_next_dt' is exercised directly against mocked inputs with a
+real FixedTimeStepCalculator as the base (away-from-pellet) calculator. The
+pellet source is read by duck typing (getattr with defaults) because its
+concrete runtime params class lives in the pellet source model, not in TORAX.
+The pellet mock therefore only exposes the declared attributes, so an omitted
+one exercises the calculator's default.
+"""
+
+from unittest import mock
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import numpy as np
+from torax._src.config import numerics as numerics_lib
+from torax._src.config import runtime_params as runtime_params_lib
+from torax._src.orchestration import sim_state as sim_state_lib
+from torax._src.time_step_calculator import chi_time_step_calculator
+from torax._src.time_step_calculator import fixed_time_step_calculator
+from torax._src.time_step_calculator import pellet_aware_time_step_calculator
+
+
+_ABLATION = 1e-3
+
+
+def _pellet(**attrs):
+  """A fake pellet source runtime params exposing only the given attributes."""
+  return mock.Mock(spec=list(attrs), **attrs)
+
+
+def _runtime_params(pellet, dt_standard):
+  """Runtime params with a 'pellet' source and a fixed base step."""
+  numerics = mock.create_autospec(
+      numerics_lib.RuntimeParams, instance=True, fixed_dt=dt_standard
+  )
+  return mock.create_autospec(
+      runtime_params_lib.RuntimeParams,
+      instance=True,
+      sources={'pellet': pellet},
+      numerics=numerics,
+  )
+
+
+def _sim_state(t, geometry=None, core_profiles=None):
+  return mock.create_autospec(
+      sim_state_lib.SimState,
+      instance=True,
+      t=t,
+      geometry=geometry,
+      core_profiles=core_profiles,
+  )
+
+
+def _calculator(**kwargs):
+  """A pellet-aware calculator with a fixed base and given overrides."""
+  kwargs.setdefault('trigger_tolerance', 1e-8)
+  return pellet_aware_time_step_calculator.PelletAwareTimeStepCalculator(
+      base_calculator=fixed_time_step_calculator.FixedTimeStepCalculator(),
+      **kwargs,
+  )
+
+
+class PelletAwareTimeStepCalculatorTest(parameterized.TestCase):
+
+  def _dt(self, pellet, t, dt_standard=0.1, calculator=None):
+    calculator = calculator or _calculator()
+    return float(
+        calculator._next_dt(
+            _runtime_params(pellet, dt_standard), _sim_state(t)
+        )
+    )
+
+  def _assert_dt(self, got, want):
+    np.testing.assert_allclose(got, want, rtol=1e-5, atol=1e-7)
+
+  @parameterized.named_parameters(
+      # Far from any trigger: the base step is used.
+      dict(testcase_name='far_before', t=0.0, want=0.1),
+      # Between triggers: the base step is used (next trigger is far).
+      dict(testcase_name='between', t=3.0, want=0.1),
+      # Approaching a trigger: dt shrinks to land exactly on it.
+      dict(testcase_name='shrink_to_first', t=1.95, want=0.05),
+      dict(testcase_name='shrink_to_second', t=5.95, want=0.05),
+      # At a trigger: the whole ablation window is a single step.
+      dict(testcase_name='at_first', t=2.0, want=_ABLATION),
+      dict(testcase_name='at_second', t=6.0, want=_ABLATION),
+  )
+  def test_trigger_times_alignment(self, t, want):
+    pellet = _pellet(trigger_times=(2.0, 6.0), ablation_time=_ABLATION)
+    self._assert_dt(self._dt(pellet, t), want)
+
+  def test_ablation_window_is_never_split(self):
+    # Even when the base step is smaller than the ablation window, the trigger
+    # step covers the whole window in one step.
+    pellet = _pellet(trigger_times=(2.0,), ablation_time=_ABLATION)
+    self._assert_dt(self._dt(pellet, t=2.0, dt_standard=1e-4), _ABLATION)
+
+  @parameterized.named_parameters(
+      # First pellet fires exactly at frequency_t_start.
+      dict(testcase_name='at_start', t=1.0, want=_ABLATION),
+      # Mid-period: the base step is used.
+      dict(testcase_name='mid_period', t=1.25, want=0.1),
+      # Approaching a boundary: dt shrinks to land exactly on it.
+      dict(testcase_name='shrink_to_boundary', t=1.45, want=0.05),
+      # Subsequent boundaries fire too.
+      dict(testcase_name='at_second_boundary', t=1.5, want=_ABLATION),
+      dict(testcase_name='at_third_boundary', t=2.0, want=_ABLATION),
+  )
+  def test_frequency_alignment(self, t, want):
+    pellet = _pellet(
+        frequency=2.0,  # period 0.5 s
+        frequency_t_start=1.0,
+        injection_enabled=True,
+        ablation_time=_ABLATION,
+    )
+    self._assert_dt(self._dt(pellet, t), want)
+
+  def test_frequency_defaults_start_to_zero(self):
+    # Without frequency_t_start the phase is measured from t=0, so a boundary
+    # sits at t=0.
+    pellet = _pellet(frequency=2.0, ablation_time=_ABLATION)
+    self._assert_dt(self._dt(pellet, t=0.0), _ABLATION)
+
+  def test_frequency_wrap_detects_near_boundary(self):
+    # A step landing a hair before a boundary (within tolerance) still fires:
+    # the phase wraps to 0 instead of staying just below the period. This guards
+    # the float robustness of the boundary detection.
+    pellet = _pellet(
+        frequency=2.0,  # period 0.5 s
+        frequency_t_start=1.0,
+        trigger_tolerance=1e-3,
+        ablation_time=_ABLATION,
+    )
+    self._assert_dt(self._dt(pellet, t=1.5 - 1e-5), _ABLATION)
+
+  def test_injection_disabled_uses_base_step(self):
+    # When the injector is off, no pellet fires and the base step is used even
+    # on a period boundary.
+    pellet = _pellet(
+        frequency=2.0,
+        frequency_t_start=1.0,
+        injection_enabled=False,
+        ablation_time=_ABLATION,
+    )
+    self._assert_dt(self._dt(pellet, t=1.0), 0.1)
+
+  def test_injection_enabled_defaults_on(self):
+    # A source that does not expose injection_enabled keeps firing.
+    pellet = _pellet(
+        frequency=2.0, frequency_t_start=1.0, ablation_time=_ABLATION
+    )
+    self._assert_dt(self._dt(pellet, t=1.0), _ABLATION)
+
+  def test_uses_source_trigger_tolerance(self):
+    # The pellet source's own trigger_tolerance takes precedence over the
+    # calculator's, so the step alignment agrees with the source's deposition.
+    pellet = _pellet(
+        trigger_times=(2.0,), ablation_time=_ABLATION, trigger_tolerance=1e-3
+    )
+    # 5e-4 away from the trigger: within the source tolerance (1e-3) but well
+    # outside the calculator default (1e-8), so the pellet fires.
+    self._assert_dt(self._dt(pellet, t=2.0005), _ABLATION)
+
+  def test_model_ablation_time_hook(self):
+    # A source exposing use_model_ablation_time and an ablation_step method sets
+    # the window from the model output, not the constant ablation_time.
+    received = {}
+
+    def ablation_step(geometry, core_profiles):
+      received['geometry'] = geometry
+      received['core_profiles'] = core_profiles
+      return None, 5e-3  # (deposited profile, ablation time)
+
+    pellet = _pellet(
+        trigger_times=(2.0,),
+        ablation_time=_ABLATION,
+        use_model_ablation_time=True,
+        ablation_step=ablation_step,
+    )
+    dt = float(
+        _calculator()._next_dt(
+            _runtime_params(pellet, 0.1),
+            _sim_state(t=2.0, geometry='geo', core_profiles='core'),
+        )
+    )
+    self._assert_dt(dt, 5e-3)
+    self.assertEqual(received['geometry'], 'geo')
+    self.assertEqual(received['core_profiles'], 'core')
+
+  @parameterized.named_parameters(
+      # Inside the post-pellet window: dt_after_pellet is used.
+      dict(testcase_name='inside_window', t=2.02, want=0.005),
+      # Near the window end: dt shrinks to land exactly on it.
+      dict(testcase_name='near_window_end', t=2.048, want=0.002),
+      # Past the window: the base step is used again.
+      dict(testcase_name='after_window', t=2.1, want=0.1),
+  )
+  def test_post_pellet_window_trigger_times(self, t, want):
+    pellet = _pellet(trigger_times=(2.0,), ablation_time=_ABLATION)
+    calculator = _calculator(window_after_pellet=0.05, dt_after_pellet=0.005)
+    self._assert_dt(self._dt(pellet, t, calculator=calculator), want)
+
+  def test_post_pellet_window_frequency(self):
+    # The post-pellet window also applies to the frequency mode, measured from
+    # the period boundary.
+    pellet = _pellet(
+        frequency=2.0, frequency_t_start=1.0, ablation_time=_ABLATION
+    )
+    calculator = _calculator(window_after_pellet=0.05, dt_after_pellet=0.005)
+    self._assert_dt(self._dt(pellet, t=1.02, calculator=calculator), 0.005)
+
+  @parameterized.named_parameters(
+      dict(
+          testcase_name='both',
+          pellet=dict(
+              trigger_times=(2.0,), frequency=2.0, ablation_time=_ABLATION
+          ),
+      ),
+      dict(testcase_name='neither', pellet=dict(ablation_time=_ABLATION)),
+  )
+  def test_requires_exactly_one_of_trigger_times_or_frequency(self, pellet):
+    with self.assertRaisesRegex(ValueError, 'exactly one'):
+      self._dt(_pellet(**pellet), t=0.0)
+
+  def test_equality_and_hash(self):
+    # Equality and hashing (needed for JAX static arguments) cover the base
+    # calculator and every alignment parameter.
+    fixed = fixed_time_step_calculator.FixedTimeStepCalculator
+    make = pellet_aware_time_step_calculator.PelletAwareTimeStepCalculator
+    calculator = make(fixed(), trigger_tolerance=1e-8)
+    self.assertEqual(calculator, make(fixed(), trigger_tolerance=1e-8))
+    self.assertEqual(
+        hash(calculator), hash(make(fixed(), trigger_tolerance=1e-8))
+    )
+    # Differing in the base calculator or any single parameter breaks equality.
+    self.assertNotEqual(
+        calculator, make(chi_time_step_calculator.ChiTimeStepCalculator())
+    )
+    self.assertNotEqual(calculator, make(fixed(), trigger_tolerance=1e-6))
+    self.assertNotEqual(calculator, make(fixed(), window_after_pellet=0.1))
+    self.assertNotEqual(calculator, make(fixed(), dt_after_pellet=0.01))
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/torax/_src/time_step_calculator/tests/pydantic_model_test.py
+++ b/torax/_src/time_step_calculator/tests/pydantic_model_test.py
@@ -18,6 +18,7 @@ import pydantic
 from torax._src import jax_utils
 from torax._src.time_step_calculator import chi_time_step_calculator
 from torax._src.time_step_calculator import fixed_time_step_calculator
+from torax._src.time_step_calculator import pellet_aware_time_step_calculator
 from torax._src.time_step_calculator import pydantic_model as time_step_pydantic_model
 
 
@@ -49,6 +50,54 @@ class PydanticModelTest(parameterized.TestCase):
         {'calculator_type': calculator_type}
     ).build_time_step_calculator()
     self.assertIsInstance(time_stepper, expected_type)
+
+  @parameterized.named_parameters(
+      dict(
+          testcase_name='default_base_is_chi',
+          config={'calculator_type': 'pellet_aware'},
+          expected_base=chi_time_step_calculator.ChiTimeStepCalculator,
+      ),
+      dict(
+          testcase_name='explicit_fixed_base',
+          config={
+              'calculator_type': 'pellet_aware',
+              'base_calculator': {'calculator_type': 'fixed'},
+          },
+          expected_base=fixed_time_step_calculator.FixedTimeStepCalculator,
+      ),
+  )
+  def test_build_pellet_aware_calculator(self, config, expected_base):
+    """Builds the pellet_aware calculator and its base calculator."""
+    calculator = time_step_pydantic_model.TimeStepCalculator.from_dict(
+        config
+    ).build_time_step_calculator()
+    self.assertIsInstance(
+        calculator,
+        pellet_aware_time_step_calculator.PelletAwareTimeStepCalculator,
+    )
+    self.assertIsInstance(calculator._base_calculator, expected_base)
+
+  @parameterized.named_parameters(
+      # A base_calculator is only meaningful for the pellet_aware calculator.
+      dict(
+          testcase_name='base_on_non_pellet_aware',
+          config={
+              'calculator_type': 'fixed',
+              'base_calculator': {'calculator_type': 'fixed'},
+          },
+      ),
+      # A pellet_aware calculator cannot wrap another pellet_aware calculator.
+      dict(
+          testcase_name='pellet_aware_base',
+          config={
+              'calculator_type': 'pellet_aware',
+              'base_calculator': {'calculator_type': 'pellet_aware'},
+          },
+      ),
+  )
+  def test_invalid_base_calculator_raises_error(self, config):
+    with self.assertRaises(pydantic.ValidationError):
+      time_step_pydantic_model.TimeStepCalculator.from_dict(config)
 
   @parameterized.named_parameters(
       dict(

--- a/torax/_src/torax_pydantic/model_config.py
+++ b/torax/_src/torax_pydantic/model_config.py
@@ -222,6 +222,32 @@ class ToraxConfig(torax_pydantic.BaseModelFrozen):
     return self
 
   @pydantic.model_validator(mode='after')
+  def _check_pellet_aware_time_step_calculator_compatibility(
+      self,
+  ) -> typing_extensions.Self:
+    """Validates that the pellet_aware calculator has a compatible pellet source."""
+    pellet_aware = (
+        time_step_calculator_pydantic_model.TimeStepCalculatorType.PELLET_AWARE
+    )
+    if self.time_step_calculator.calculator_type != pellet_aware:
+      return self
+    if self.sources.pellet is None:
+      raise ValueError(
+          "time_step_calculator.calculator_type='pellet_aware' requires a"
+          " pellet source to be configured under sources.pellet."
+      )
+    has_trigger_times = hasattr(self.sources.pellet, 'trigger_times')
+    has_frequency = hasattr(self.sources.pellet, 'frequency')
+    has_ablation_time = hasattr(self.sources.pellet, 'ablation_time')
+    if not ((has_trigger_times or has_frequency) and has_ablation_time):
+      raise ValueError(
+          "time_step_calculator.calculator_type='pellet_aware' requires a"
+          " pellet source supporting discrete pellet injection ('trigger_times'"
+          " or 'frequency', and 'ablation_time')' "
+      )
+    return self
+
+  @pydantic.model_validator(mode='after')
   def _validate_extended_lengyel_and_impurity_mode(
       self,
   ) -> typing_extensions.Self:

--- a/torax/_src/torax_pydantic/tests/model_config_test.py
+++ b/torax/_src/torax_pydantic/tests/model_config_test.py
@@ -311,6 +311,23 @@ class ConfigTest(parameterized.TestCase):
     ):
       model_config.ToraxConfig.from_dict(config_dict)
 
+  def test_pellet_aware_calculator_without_pellet_source_raises_error(self):
+    config_dict = default_configs.get_default_config_dict()
+    config_dict["time_step_calculator"] = {"calculator_type": "pellet_aware"}
+    with self.assertRaisesRegex(ValueError, "requires a pellet source"):
+      model_config.ToraxConfig.from_dict(config_dict)
+
+  def test_pellet_aware_calculator_with_incompatible_source_raises_error(self):
+    config_dict = default_configs.get_default_config_dict()
+    # The default pellet source does not support discrete pellet injection
+    # (no trigger_times/frequency and ablation_time).
+    config_dict["sources"] = {**config_dict["sources"], "pellet": {}}
+    config_dict["time_step_calculator"] = {"calculator_type": "pellet_aware"}
+    with self.assertRaisesRegex(
+        ValueError, "supporting discrete pellet injection"
+    ):
+      model_config.ToraxConfig.from_dict(config_dict)
+
   @parameterized.named_parameters(
       ("good_config", None, False, ""),
       (


### PR DESCRIPTION
New time step calculator named pellet_aware_time_step_calculator, created for the coupling between TORAX and HPI2-NN, that aligns time steps with pellet injection (trigger) times and ablation windows, resolving each ablation window as a single step. Generic for every pellet source with trigger_times/frequency and ablation_time in their runtime parameters. Also Added documentation for this new time step calculator and the HPI2-NN pellet source.