### PR TITLE
Add crash suppression windows to sawtooth trigger models.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -2497,6 +2497,15 @@ sawtooth
   The minimum normalized radius (:math:`\hat{\rho}`) of the q=1 surface required
   to trigger a crash.
 
+* ``suppression_times`` (tuple[float, ...] [default = ()])
+  Times [s] of events after which sawtooth crashes are suppressed. Empty by default (no suppression). 
+  Available on all trigger models.
+
+* ``suppression_duration`` (float | tuple[float, ...] [default = 0.0])
+  Duration [s] of the suppression window opened by each entry of ``suppression_times``. 
+  A scalar applies to all of them, a list gives a per-event value and must then have the 
+  same length as ``suppression_times``.
+
 ``model_name`` (str [default = 'simple'])
   Currently only 'simple' is supported.
 

--- a/torax/_src/mhd/sawtooth/runtime_params.py
+++ b/torax/_src/mhd/sawtooth/runtime_params.py
@@ -26,9 +26,13 @@ class TriggerRuntimeParams:
 
   Attributes:
     minimum_radius: Minimum radius of q=1 surface for triggering [rho_norm].
+    suppression_times: Times [s] of events after which crashes are suppressed.
+    suppression_duration: Duration [s] of the window opened by each event.
   """
 
   minimum_radius: array_typing.FloatScalar
+  suppression_times: tuple[float, ...]
+  suppression_duration: array_typing.FloatScalar | tuple[float, ...]
 
 
 @jax.tree_util.register_dataclass

--- a/torax/_src/mhd/sawtooth/simple_trigger.py
+++ b/torax/_src/mhd/sawtooth/simple_trigger.py
@@ -37,7 +37,7 @@ class SimpleTrigger(
 ):
   """Simple trigger model."""
 
-  def __call__(
+  def compute_trigger(
       self,
       runtime_params: runtime_params_lib.RuntimeParams,
       geo: geometry.Geometry,

--- a/torax/_src/mhd/sawtooth/tests/simple_trigger_test.py
+++ b/torax/_src/mhd/sawtooth/tests/simple_trigger_test.py
@@ -124,6 +124,8 @@ class SimpleTriggerTest(parameterized.TestCase):
                 trigger_params=simple_trigger.RuntimeParams(
                     s_critical=s_critical,
                     minimum_radius=minimum_radius,
+                    suppression_times=(),
+                    suppression_duration=0.0,
                 ),
             )
         ),

--- a/torax/_src/mhd/sawtooth/trigger_base.py
+++ b/torax/_src/mhd/sawtooth/trigger_base.py
@@ -18,6 +18,8 @@ import abc
 import dataclasses
 
 import chex
+from jax import numpy as jnp
+import pydantic
 from torax._src import array_typing
 from torax._src import state
 from torax._src import static_dataclass
@@ -31,8 +33,53 @@ from torax._src.torax_pydantic import torax_pydantic
 class TriggerModel(static_dataclass.StaticDataclass, abc.ABC):
   """Abstract base class for sawtooth trigger models."""
 
-  @abc.abstractmethod
   def __call__(
+      self,
+      runtime_params: runtime_params_lib.RuntimeParams,
+      geo: geometry.Geometry,
+      core_profiles: state.CoreProfiles,
+  ) -> tuple[array_typing.BoolScalar, array_typing.FloatScalar]:
+    """Indicates if a crash is triggered and the radius of the q=1 surface.
+
+    Delegates the trigger condition itself to the concrete model, then applies
+    the crash suppression windows. This is used to block crashes around a prescribed 
+    event. No window is configured by default.
+    Args:
+      runtime_params: Runtime parameters.
+      geo: Geometry object.
+      core_profiles: Core plasma profiles.
+
+    Returns:
+      tuple of (True if sawtooth crash is triggered, False otherwise,
+        radius of q=1 surface (set to 0.0 if no surface exists))
+    """
+    trigger, rho_norm_q1 = self.compute_trigger(
+        runtime_params, geo, core_profiles
+    )
+
+    sawtooth_params = runtime_params.mhd.sawtooth
+    assert isinstance(sawtooth_params, sawtooth_runtime_params.RuntimeParams)
+    trigger_params = sawtooth_params.trigger_params
+    if trigger_params.suppression_times:
+      t = jnp.asarray(runtime_params.t)
+      times = jnp.asarray(trigger_params.suppression_times, dtype=t.dtype)
+      durations = jnp.broadcast_to(
+          jnp.asarray(trigger_params.suppression_duration, dtype=t.dtype),
+          times.shape,
+      )
+      tol = jnp.asarray(1e-8, dtype=t.dtype)
+      # Suppression window is half-open: [t_event, t_event + duration).
+      in_suppression_window = jnp.any(
+          jnp.logical_and(t >= times - tol, t < times + durations)
+      )
+      trigger = jnp.logical_and(
+          trigger, jnp.logical_not(in_suppression_window)
+      )
+
+    return trigger, rho_norm_q1
+
+  @abc.abstractmethod
+  def compute_trigger(
       self,
       runtime_params: runtime_params_lib.RuntimeParams,
       geo: geometry.Geometry,
@@ -46,15 +93,36 @@ class TriggerConfig(torax_pydantic.BaseModelFrozen):
 
   Attributes:
     minimum_radius: The minimum radius of the q=1 surface for triggering.
+    suppression_times: Times [s] of events after which sawtooth crashes are
+      suppressed. Empty by default.
+    suppression_duration: Duration [s] of the suppression window opened by each
+      entry of suppression_times. A scalar applies to all of them, a list gives
+      a per-event value and must then have the same length.
   """
 
   minimum_radius: torax_pydantic.PositiveTimeVaryingScalar = (
       torax_pydantic.ValidatedDefault(0.05)
   )
+  suppression_times: tuple[float, ...] = ()
+  suppression_duration: float | tuple[float, ...] = 0.0
+
+  @pydantic.model_validator(mode='after')
+  def _validate_suppression_windows(self):
+    if isinstance(self.suppression_duration, tuple) and len(
+        self.suppression_duration
+    ) != len(self.suppression_times):
+      raise ValueError(
+          'suppression_duration length'
+          f' ({len(self.suppression_duration)}) must match suppression_times'
+          f' length ({len(self.suppression_times)}).'
+      )
+    return self
 
   def build_runtime_params(
       self, t: chex.Numeric
   ) -> sawtooth_runtime_params.TriggerRuntimeParams:
     return sawtooth_runtime_params.TriggerRuntimeParams(
         minimum_radius=self.minimum_radius.get_value(t),
+        suppression_times=self.suppression_times,
+        suppression_duration=self.suppression_duration,
     )


### PR DESCRIPTION
Add suppression_times and suppression_duration to the base sawtooth TriggerConfig, while the current time is within [t_event, t_event + duration) of any suppression_times entry, crashes are suppressed. Both default to empty/zero. This lets crashes be blocked around a prescribed event. It was created for the coupling between TORAX and HPI2-NN, where pellet injection can currently conflict with the simple sawtooth model. It provides a tool to handle that case if it happens. The tool itself is generic.

The logic lives in the base TriggerModel.__call__, which now delegates the trigger condition to a new abstract compute_trigger, trigger models(e.g. SimpleTrigger) define compute_trigger instead of __call__.