### PR TITLE
Animate prebuilt frames from the plotting slider

### DIFF
--- a/torax/_src/plotting/plotruns_lib.py
+++ b/torax/_src/plotting/plotruns_lib.py
@@ -748,14 +748,102 @@ def _add_traces_and_update_axes(
   return spatial_traces_info, timestamp_line_info
 
 
-def _get_slider_steps(
+# Animation options used by the slider steps. 'immediate' jumps straight to the
+# requested frame, and redraw=False updates the traces in place instead of
+# re-rendering the whole figure, which dominates the cost of a slider move.
+_ANIMATION_ARGS: Final[dict[str, Any]] = {
+    'mode': 'immediate',
+    'frame': {'duration': 0, 'redraw': False},
+    'transition': {'duration': 0},
+}
+
+
+def _get_trace_update(
+    t_val: float,
+    spatial_traces_info: list[dict[str, Any]],
+    timestamp_line_info: list[dict[str, Any]],
+) -> tuple[dict[str, Any], list[int]]:
+  """Returns the (restyle args, trace indices) showing a single timepoint."""
+  y_updates = []
+  x_updates = []
+  trace_indices = []
+
+  for info in spatial_traces_info:
+    # Find the nearest time index in this dataset for the target time.
+    dataset_t = info['dataset'].t
+    nearest_t_idx = int(np.argmin(np.abs(dataset_t - t_val)))
+    val_array = getattr(info['dataset'], info['attr'])
+    y_updates.append(val_array[nearest_t_idx, :])
+    x_updates.append(info['x'])
+    trace_indices.append(info['trace_idx'])
+
+  for info in timestamp_line_info:
+    y_updates.append(info['y'])
+    x_updates.append([t_val, t_val])
+    trace_indices.append(info['trace_idx'])
+
+  return {'y': y_updates, 'x': x_updates}, trace_indices
+
+
+def _build_frames(
     data1: PlotData,
     spatial_traces_info: list[dict[str, Any]],
     timestamp_line_info: list[dict[str, Any]],
+) -> list[go.Frame]:
+  """Builds one animation frame per timestep of the master clock.
+
+  Slider steps animate to these frames rather than carrying the data
+  themselves, so that each timepoint is stored once and moving the slider
+  updates the traces in place instead of re-rendering the whole figure.
+
+  Args:
+    data1: The dataset used as the master clock for the frames.
+    spatial_traces_info: Info on the traces updated by the slider.
+    timestamp_line_info: Info on the vertical lines marking the current time.
+
+  Returns:
+    A list of frames, named by their index in ``data1.t``.
+  """
+  # Fetch each profile once rather than per frame, since attribute access on
+  # PlotData converts the underlying xarray variable to a numpy array.
+  spatial_data = [
+      (info['dataset'].t, getattr(info['dataset'], info['attr']))
+      for info in spatial_traces_info
+  ]
+
+  frames = []
+  for frame_idx, t_val in enumerate(data1.t):
+    frame_data = []
+    trace_indices = []
+
+    for info, (dataset_t, val_array) in zip(
+        spatial_traces_info, spatial_data, strict=True
+    ):
+      # Find the nearest time index in this dataset for the target time.
+      nearest_t_idx = int(np.argmin(np.abs(dataset_t - t_val)))
+      # x is static for spatial traces, so only y is carried by the frame.
+      frame_data.append({'y': val_array[nearest_t_idx, :]})
+      trace_indices.append(info['trace_idx'])
+
+    for info in timestamp_line_info:
+      frame_data.append({'x': [t_val, t_val]})
+      trace_indices.append(info['trace_idx'])
+
+    frames.append(
+        go.Frame(
+            name=str(frame_idx),
+            data=frame_data,
+            traces=trace_indices,
+        )
+    )
+  return frames
+
+
+def _get_slider_steps(
+    data1: PlotData,
     linear_time: bool = False,
 ) -> list[dict[str, Any]]:
-  """Generates slider steps for spatial plots."""
-  steps = []
+  """Generates slider steps animating to the frames built by _build_frames."""
   # If linear_time is True, the slider ticks will be linearly spaced in time.
   # Otherwise, the slider ticks will follow the timesteps taken by the sim.
   # Ticks will always use data1 as the master clock.
@@ -768,31 +856,15 @@ def _get_slider_steps(
   else:
     t_vals = data1.t
 
+  steps = []
   for t_val in t_vals:
-    y_updates = []
-    x_updates = []
-    trace_indices = []
-
-    for info in spatial_traces_info:
-      # Find the nearest time index in this dataset for the target time.
-      dataset_t = info['dataset'].t
-      nearest_t_idx = int(np.argmin(np.abs(dataset_t - t_val)))
-      val_array = getattr(info['dataset'], info['attr'])
-      y_updates.append(val_array[nearest_t_idx, :])
-      x_updates.append(info['x'])
-      trace_indices.append(info['trace_idx'])
-
-    for info in timestamp_line_info:
-      y_updates.append(info['y'])
-      x_updates.append([t_val, t_val])
-      trace_indices.append(info['trace_idx'])
-
-    step = {
-        'method': 'restyle',
+    # Both slider modes share the same frames, and thus the same data.
+    frame_idx = int(np.argmin(np.abs(data1.t - t_val)))
+    steps.append({
+        'method': 'animate',
         'label': f'{t_val:.3f}s',
-        'args': [{'y': y_updates, 'x': x_updates}, trace_indices],
-    }
-    steps.append(step)
+        'args': [[str(frame_idx)], _ANIMATION_ARGS],
+    })
   return steps
 
 
@@ -813,11 +885,15 @@ def _build_slider(
   new_margin['b'] = new_margin.get('b', 50) + 100
   fig.update_layout(margin=new_margin)
 
-  steps_timesteps = _get_slider_steps(
-      data1, spatial_traces_info, timestamp_line_info, linear_time=False
-  )
-  steps_linear_time = _get_slider_steps(
-      data1, spatial_traces_info, timestamp_line_info, linear_time=True
+  fig.frames = _build_frames(data1, spatial_traces_info, timestamp_line_info)
+
+  steps_timesteps = _get_slider_steps(data1, linear_time=False)
+  steps_linear_time = _get_slider_steps(data1, linear_time=True)
+
+  # Switching slider mode resets the figure to the first timepoint, which the
+  # buttons apply directly since a button cannot both relayout and animate.
+  first_trace_update, first_trace_indices = _get_trace_update(
+      data1.t[0], spatial_traces_info, timestamp_line_info
   )
 
   slider_linear_time = {
@@ -841,24 +917,24 @@ def _build_slider(
               buttons=[
                   dict(
                       args=[
-                          steps_linear_time[0]['args'][0],
+                          first_trace_update,
                           {
                               'sliders[0].steps': steps_linear_time,
                               'sliders[0].active': 0,
                           },
-                          steps_linear_time[0]['args'][1],
+                          first_trace_indices,
                       ],
                       label='Plasma time',
                       method='update',
                   ),
                   dict(
                       args=[
-                          steps_timesteps[0]['args'][0],
+                          first_trace_update,
                           {
                               'sliders[0].steps': steps_timesteps,
                               'sliders[0].active': 0,
                           },
-                          steps_timesteps[0]['args'][1],
+                          first_trace_indices,
                       ],
                       label='Simulation steps',
                       method='update',

--- a/torax/_src/plotting/plotruns_lib_test.py
+++ b/torax/_src/plotting/plotruns_lib_test.py
@@ -258,5 +258,82 @@ class PlotDataTest(absltest.TestCase):
       _ = self.plot_data.non_existent_var
 
 
+class SliderFramesTest(absltest.TestCase):
+  """Tests that the slider animates prebuilt frames instead of carrying data."""
+
+  @classmethod
+  def setUpClass(cls):
+    super().setUpClass()
+    data_path = paths.test_data_dir() / 'test_iterhybrid_rampup.nc'
+    config_path = path_utils.torax_path().joinpath(
+        'plotting', 'configs', 'default_plot_config.py'
+    )
+    plot_config = config_loader.import_module(config_path)['PLOT_CONFIG']
+    cls.plot_data = plotruns_lib.load_data(str(data_path))
+    cls.fig = plotruns_lib.plot_run(
+        plot_config, {'Data 1': str(data_path)}, interactive=False
+    )
+
+  def test_slider_steps_animate_to_existing_frames(self):
+    frame_names = {frame.name for frame in self.fig.frames}
+    self.assertLen(frame_names, len(self.plot_data.t))
+
+    for step in self.fig.layout.sliders[0].steps:
+      self.assertEqual(step.method, 'animate')
+      # Steps only reference a frame and the animation options: no data.
+      frame_names_arg, animation_opts = step.args
+      self.assertIn(frame_names_arg[0], frame_names)
+      self.assertEqual(animation_opts['mode'], 'immediate')
+      self.assertFalse(animation_opts['frame']['redraw'])
+      self.assertEqual(animation_opts['transition']['duration'], 0)
+
+  def test_frames_carry_profiles_without_static_x(self):
+    # The first trace of default_plot_config is the T_i profile.
+    self.assertIsNotNone(self.fig.data[0].x)
+    for frame_idx, frame in enumerate(self.fig.frames):
+      self.assertEqual(frame.traces[0], 0)
+      np.testing.assert_array_equal(
+          frame.data[0].y, self.plot_data.T_i[frame_idx, :]
+      )
+      # x is static for the profiles, so it stays on the trace itself.
+      self.assertIsNone(frame.data[0].x)
+
+  def test_frames_move_the_current_time_lines(self):
+    line_indices = [
+        idx
+        for idx, trace in enumerate(self.fig.data)
+        if trace.name == 'Current Time'
+    ]
+    self.assertNotEmpty(line_indices)
+
+    for frame_idx, frame in enumerate(self.fig.frames):
+      t_val = self.plot_data.t[frame_idx]
+      for line_idx in line_indices:
+        frame_data = frame.data[frame.traces.index(line_idx)]
+        np.testing.assert_array_equal(frame_data.x, [t_val, t_val])
+        # The line spans the full y range of its subplot, which never changes.
+        self.assertIsNone(frame_data.y)
+
+  def test_both_slider_modes_share_the_same_frames(self):
+    frame_names = {frame.name for frame in self.fig.frames}
+    buttons = self.fig.layout.updatemenus[0].buttons
+    self.assertLen(buttons, 2)
+
+    for button in buttons:
+      trace_update, layout_update, trace_indices = button.args
+      steps = layout_update['sliders[0].steps']
+      self.assertLen(steps, len(frame_names))
+      for step in steps:
+        self.assertEqual(step['method'], 'animate')
+        self.assertIn(step['args'][0][0], frame_names)
+
+      # Switching mode resets the figure to the first timepoint.
+      self.assertEqual(layout_update['sliders[0].active'], 0)
+      self.assertEqual(trace_indices[0], 0)
+      np.testing.assert_array_equal(
+          trace_update['y'][0], self.plot_data.T_i[0, :]
+      )
+
+
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
# Animate prebuilt frames from the plotting slider

Fixes #553. Follow-up to #2285, which I closed after measuring that payload size
is not what makes the slider slow — this PR targets the thing that is.

## Why the slider is slow

From the profile in https://github.com/google-deepmind/torax/pull/2285#issuecomment-5113182237:
one slider move costs a full re-render of the figure. Restyling one trace costs
the same as restyling all 32, and a `Plotly.redraw()` that changes no data at all
costs the same again. Slider steps currently carry the data and apply it with
`Plotly.restyle`, so every move pays for a re-render.

## What this changes

* Each timepoint is stored once as a Plotly **frame** (`fig.frames`), holding `y`
  for the profile traces and `x` for the "current time" vertical lines. `x` for
  the profiles is static, so it stays on the trace and is no longer re-sent.
* Slider steps become `method: 'animate'` with `frame: {redraw: false}`: they
  reference a frame name instead of carrying data, and the traces are updated in
  place instead of the figure being re-rendered.
* Both slider modes ("Plasma time", "Simulation steps") reference the same
  frames, so per-timepoint data is no longer serialized once per mode inside
  `updatemenus`.

## Per-move latency

Headless Chromium (Playwright), `default_plot_config`, each step applied exactly
as plotly's slider applies it, timed to the second painted frame. Both pages are
open at once and sweeps are interleaved A/B — absolute numbers move by up to 2x
between runs on my machine, so a non-interleaved comparison is not trustworthy.
Median of 5 rounds of 25 moves.

| run | saved timesteps | main | this PR |
|---|---|---|---|
| `test_iterhybrid_rampup` | 41 | 153 ms | **67 ms** |
| `basic_config`, `t_final=25` | 106 | 176 ms | **67 ms** |

The new path does not scale with the number of saved timesteps; the old one does.
Dragging the rail with real mouse events shows the same behaviour.

## Payload and build

Medians of 3 repeats in-process (`create_plotly_figure` + `plotly.io.to_html`,
the `fig.show()` path).

| | rampup, main | rampup, PR | 106-step, main | 106-step, PR |
|---|---|---|---|---|
| figure JSON | 1.90 MB | 0.44 MB | 4.45 MB | 1.09 MB |
| full HTML page | 6.74 MB | 5.29 MB | 9.30 MB | 5.94 MB |
| figure build | 0.29 s | 0.37 s | 0.52 s | 0.45 s |
| serialize | 0.102 s | 0.061 s | 0.249 s | 0.129 s |

Build time goes up by ~0.08 s on the 41-step run: frames are validated by
plotly.py as (partial) traces. It goes down on the 106-step run because the
profiles are now fetched from the `PlotData` once per trace instead of once per
trace per slider step. Two slider moves pay for the worst case either way.

Time from opening the page to the first painted plot is unchanged (~1.1 s,
median of 5 fresh loads, both runs): that is dominated by parsing the 4.84 MB of
inlined plotly.js, which this PR does not touch. Consistent with the manual
testing on #2285 — page weight was never the bottleneck.

## Behaviour

Compared per-trace `x`/`y` of every trace between main and this branch, in both
slider modes, at 4 timepoints each:

* **Simulation steps** mode: identical, every trace, every probed step.
* **Plasma time** mode: all profiles identical. The only difference is the
  "current time" vertical lines, which now sit at the actual saved time of the
  profile being displayed instead of the interpolated tick value. Both modes
  share one frame per saved timestep, so the line follows the data rather than
  the tick. Worst-case offset is half a saved-timestep interval: 0 s for
  `test_iterhybrid_rampup` (uniform `dt`), 0.12 s of a 25 s axis for the
  adaptive-`dt` 106-step run. If you would rather keep the line exactly on the
  tick, say so and I will label the ticks with the frame's real time instead
  (one line), or give the linear-time mode its own frames for the line position.

Screenshots of the whole figure at the same timepoint are pixel-identical apart
from the slider handle, which now follows the animated frame (plotly syncs it
for `animate` steps) instead of staying where it was left.

## Tests

`SliderFramesTest` in `plotruns_lib_test.py` covers: steps animate to frames
that exist and carry no data; frames carry each timepoint's profile and no
static `x`; frames move the current-time lines; both modes share the frames and
reset to the first timepoint. Full plotting suite: 235 passed.

Also checked manually that comparing two runs with different time grids still
picks each dataset's nearest timepoint per frame.

## Reproducing

Build a page with `plotruns_lib.create_plotly_figure` + `plotly.io.to_html`,
then drive `layout.sliders[0].steps[i]` through `Plotly.animate` / `Plotly.restyle`
in Playwright, timing to the second `requestAnimationFrame`. Happy to attach the
scripts if useful.
