### PR TITLE
Add TokaMaker geometry interface

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1141,6 +1141,15 @@ geometry
     (IDS) or directly the equilibrium IDS on the fly. It handles IDSs in Data
     Dictionary version 4.0.0.
 
+* ``'tokamaker'``
+    Takes flux surface averages computed by
+    `TokaMaker <https://github.com/openfusiontoolkit/OpenFUSIONToolkit>`_.
+    TokaMaker traces flux surfaces on the finite element mesh used for the
+    equilibrium solve, then passes arrays of flux surface averaged quantities
+    to TORAX. TORAX does not depend on TokaMaker (or Open FUSION Toolkit),
+    the geometry information is passed as plain arrays, which can be done
+    without saving and loading files.
+
 Geometry dicts for all geometry types can contain the following additional keys.
 
 ``calcphibdot`` (bool [default = True])
@@ -1184,7 +1193,7 @@ Geometry dicts for all geometry types can contain the following additional keys.
   ``j`` to ``psi`` conversions.
 
 
-Geometry dicts for all non-circular geometry types can contain the following
+Geometry dicts for all geometry types, except ``circular`` and ``tokamaker``, can contain the following
 additional keys.
 
 ``geometry_file`` (str) See below for information on defaults
@@ -1270,6 +1279,48 @@ It is only recommended to change the default values if issues arise.
   Multiplication factor of the boundary poloidal flux, used for the contour
   defining geometry terms at the LCFS on the TORAX grid. Needed to avoid
   divergent integrations in diverted geometries.
+
+Geometry dicts for TokaMaker geometry require the following key.
+
+``fsa_profiles`` (dict[str, np.ndarray | float])
+  Flux surface averaged profiles, as returned by ``TokaMaker_equilibrium.get_fsa()``.
+  Pass the dict straight through:
+
+  .. code-block:: python
+
+    'geometry': {
+        'geometry_type': 'tokamaker',
+        'n_rho': 25,
+        'fsa_profiles': my_equilibrium.get_fsa(npsi=100),
+    }
+
+  A time-dependent geometry is built by giving one equilibrium per time in
+  ``geometry_configs``:
+
+  .. code-block:: python
+
+    'geometry': {
+        'geometry_type': 'tokamaker',
+        'n_rho': 25,
+        'geometry_configs': {
+            t: {'fsa_profiles': eq.get_fsa(npsi=100)} for t, eq in equilibria.items()
+        },
+    }
+
+  The number of flux surfaces and the outermost surface sampled are set by the
+  ``get_fsa()`` call rather than by this config. The outermost sampled surface
+  becomes :math:`\hat{\rho} = 1` in TORAX, so ``get_fsa(psi_pad=0.01)`` plays
+  the same role as ``last_surface_factor = 0.99`` does for EQDSK geometry.
+
+  Note that a flux surface grid uniform in normalized poloidal flux is sparse
+  in :math:`\hat{\rho}` near the axis, since
+  :math:`\hat{\rho} \propto \sqrt{\hat{\psi}}` there. Sampling uniformly in
+  :math:`\sqrt{\hat{\psi}}` gives a well resolved TORAX grid:
+
+  .. code-block:: python
+
+    psi_norm = np.linspace(np.sqrt(1e-4), np.sqrt(0.99), 100) ** 2
+    fsa = my_equilibrium.get_fsa(psi=psi_norm)
 
 Geometry dicts for IMAS geometry require one and only one of the following
 additional keys.

--- a/torax/_src/geometry/geometry.py
+++ b/torax/_src/geometry/geometry.py
@@ -57,6 +57,7 @@ class GeometryType(enum.IntEnum):
   FBT = 2
   EQDSK = 3
   IMAS = 4
+  TOKAMAKER = 5
 
 
 # pylint: disable=invalid-name

--- a/torax/_src/geometry/pydantic_model.py
+++ b/torax/_src/geometry/pydantic_model.py
@@ -27,6 +27,7 @@ from torax._src.geometry import geometry
 from torax._src.geometry import geometry_provider
 from torax._src.geometry import imas
 from torax._src.geometry import standard_geometry
+from torax._src.geometry import tokamaker
 from torax._src.torax_pydantic import torax_pydantic
 
 T = TypeVar('T')
@@ -41,6 +42,7 @@ class GeometryConfig(torax_pydantic.BaseModelFrozen):
       | fbt.FBTConfig
       | eqdsk.EQDSKConfig
       | imas.IMASConfig
+      | tokamaker.TokaMakerConfig
   ) = pydantic.Field(discriminator='geometry_type')
 
 

--- a/torax/_src/geometry/tests/tokamaker_test.py
+++ b/torax/_src/geometry/tests/tokamaker_test.py
@@ -1,0 +1,281 @@
+# Copyright 2026 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from absl.testing import absltest
+from absl.testing import parameterized
+import numpy as np
+from torax._src import constants
+from torax._src.geometry import pydantic_model
+from torax._src.geometry import standard_geometry
+from torax._src.geometry import tokamaker
+
+# pylint: disable=invalid-name
+
+_R_MAJOR = 6.2
+_A_MINOR = 2.0
+_B_0 = 5.3
+
+
+def _circular_get_fsa(n_surfaces: int = 60, a_minor: float = _A_MINOR) -> dict:
+  """Builds a dummy `TokaMaker_equilibrium.get_fsa()`-shaped dict for a concentric
+  circular equilibrium, without using TokaMaker.
+
+  Flux surfaces are circles of minor radius r about (R_major, 0) with a
+  poloidal field uniform on each surface, so every flux surface average has a
+  closed form. Quantities follow TokaMaker's conventions, i.e. poloidal flux in
+  Wb/rad with B_p = |grad(psi)|/R.
+  """
+  r = np.linspace(a_minor / n_surfaces, a_minor, n_surfaces)
+  q = 1.0 + 2.0 * (r / a_minor) ** 2
+  # F = R*B_phi, constant with no diamagnetism.
+  F = np.full_like(r, _R_MAJOR * _B_0)
+  # q = r*B_0/(R_major*B_p) for a large aspect ratio circular surface.
+  Bp = r * _B_0 / (_R_MAJOR * q)
+  # With B_p uniform on the surface the averaging weight dl/B_p is uniform in
+  # the poloidal angle, so <f> reduces to the plain angular mean.
+  sqrt_term = np.sqrt(_R_MAJOR**2 - r**2)
+  flux_surf_avg_1_over_R = 1.0 / sqrt_term
+  flux_surf_avg_1_over_R2 = _R_MAJOR / sqrt_term**3
+  # int(dl/B_p) over a circle of circumference 2*pi*r.
+  int_dl_over_Bp = 2.0 * np.pi * r / Bp
+  theta = np.linspace(0.0, 2.0 * np.pi, 512, endpoint=False)
+  R_theta = _R_MAJOR + r[:, None] * np.cos(theta)[None, :]
+  B2 = Bp[:, None] ** 2 + (F[:, None] / R_theta) ** 2
+  # psi in Wb/rad, from dpsi/dr = R*B_p evaluated at the surface average of R.
+  # Integrated from the axis, where B_p vanishes, so that the innermost traced
+  # surface carries a nonzero flux as it does in a real `get_fsa()` grid.
+  r_full = np.concatenate([[0.0], r])
+  Bp_full = np.concatenate([[0.0], Bp])
+  psi = np.cumsum(
+      np.diff(r_full) * _R_MAJOR * 0.5 * (Bp_full[1:] + Bp_full[:-1])
+  )
+  return {
+      'psi': psi,
+      'q': q,
+      'F': F,
+      '<R>': np.full_like(r, _R_MAJOR),
+      '<1/R>': flux_surf_avg_1_over_R,
+      '<1/R^2>': flux_surf_avg_1_over_R2,
+      # TokaMaker returns dV/dPsi = 2*pi*int(dl/B_p), negative for this
+      # orientation of the normalized flux coordinate.
+      'dV/dPsi': -2.0 * np.pi * int_dl_over_Bp,
+      '<|grad psi|>': _R_MAJOR * Bp,
+      '<|grad psi|^2>': Bp**2 * (_R_MAJOR**2 + r**2 / 2.0),
+      '<Bp^2>': Bp**2,
+      '<1/B^2>': np.mean(1.0 / B2, axis=1),
+      'R_min': _R_MAJOR - r,
+      'R_max': _R_MAJOR + r,
+      'Z_min': -r,
+      'Z_max': r,
+      'R_at_Zmin': np.full_like(r, _R_MAJOR),
+      'R_at_Zmax': np.full_like(r, _R_MAJOR),
+      'psi_axis': 0.0,
+      'R_axis': _R_MAJOR,
+      'Z_axis': 0.0,
+      'F_axis': _R_MAJOR * _B_0,
+      'F0': _R_MAJOR * _B_0,
+      'diverted': False,
+  }
+
+
+class TokaMakerGeometryTest(parameterized.TestCase):
+
+  def test_build_geometry_from_get_fsa_dict(self):
+    """A `get_fsa()` dict is accepted directly as the equilibrium input."""
+    config = tokamaker.TokaMakerConfig(fsa_profiles=_circular_get_fsa())
+    geo = config.build_geometry()
+    self.assertEqual(geo.torax_mesh.nx, 25)
+
+  def test_unrecognized_get_fsa_keys_are_ignored(self):
+    """Extra keys, such as '<R>', do not need to be stripped by the caller."""
+    fsa = _circular_get_fsa() | {'some_future_key': np.zeros(3)}
+    tokamaker.TokaMakerConfig(fsa_profiles=fsa).build_geometry()
+
+  def test_inconsistent_profile_lengths_raises(self):
+    fsa = _circular_get_fsa()
+    fsa['q'] = fsa['q'][:-1]
+    with self.assertRaisesRegex(ValueError, 'inconsistent lengths'):
+      tokamaker.TokaMakerConfig(fsa_profiles=fsa)
+
+  @parameterized.parameters(
+      dict(name='R_major', expected=_R_MAJOR),
+      dict(name='a_minor', expected=_A_MINOR),
+      dict(name='B_0', expected=_B_0),
+  )
+  def test_reference_scalars(self, name, expected):
+    """Reference scalars come from the outermost surface and F0."""
+    geo = tokamaker.TokaMakerConfig(
+        fsa_profiles=_circular_get_fsa()
+    ).build_geometry()
+    np.testing.assert_allclose(getattr(geo, name), expected, rtol=1e-12)
+
+  def test_cocos11_unit_conversions(self):
+    """TokaMaker psi is Wb/rad, so COCOS 11 quantities pick up 2*pi factors."""
+    fsa = _circular_get_fsa()
+    intermediates = tokamaker._construct_intermediates_from_tokamaker(  # pylint: disable=protected-access
+        equilibrium=tokamaker.TokaMakerEquilibrium.from_dict(fsa),
+        Ip_from_parameters=True,
+        face_centers=np.linspace(0.0, 1.0, 26),
+        hires_factor=4,
+    )
+    # Index 0 is the prescribed magnetic axis row, so compare from index 1.
+    np.testing.assert_allclose(
+        intermediates.psi[1:], 2 * np.pi * fsa['psi'], rtol=1e-12
+    )
+    np.testing.assert_allclose(
+        intermediates.int_dl_over_Bp[1:],
+        np.abs(fsa['dV/dPsi']) / (2 * np.pi),
+        rtol=1e-12,
+    )
+    # <B^2> = <B_p^2> + F^2<1/R^2>, since F is constant on a flux surface.
+    np.testing.assert_allclose(
+        intermediates.flux_surf_avg_B2[1:],
+        fsa['<Bp^2>'] + fsa['F'] ** 2 * fsa['<1/R^2>'],
+        rtol=1e-12,
+    )
+    # The gradient averages are additionally smoothed near the axis by
+    # StandardGeometryIntermediates, so only compare outside that region.
+    rho_norm = np.sqrt(intermediates.Phi / intermediates.Phi[-1])[1:]
+    outer = rho_norm > 2.0 * standard_geometry._RHO_SMOOTHING_LIMIT  # pylint: disable=protected-access
+    for got, want in (
+        (intermediates.flux_surf_avg_grad_psi, 2 * np.pi * fsa['<|grad psi|>']),
+        (
+            intermediates.flux_surf_avg_grad_psi2,
+            4 * np.pi**2 * fsa['<|grad psi|^2>'],
+        ),
+        (
+            intermediates.flux_surf_avg_grad_psi2_over_R2,
+            4 * np.pi**2 * fsa['<Bp^2>'],
+        ),
+    ):
+      np.testing.assert_allclose(got[1:][outer], want[outer], rtol=1e-12)
+
+  def test_Ip_profile_matches_ampere_law(self):
+    """Ip = <B_p^2> int(dl/B_p) / mu_0, with int(dl/B_p) = |dV/dPsi|/(2*pi)."""
+    fsa = _circular_get_fsa()
+    geo = tokamaker.TokaMakerConfig(fsa_profiles=fsa).build_geometry()
+    int_dl_over_Bp = np.abs(fsa['dV/dPsi'][-1]) / (2 * np.pi)
+    expected = fsa['<Bp^2>'][-1] * int_dl_over_Bp / constants.CONSTANTS.mu_0
+    np.testing.assert_allclose(geo.Ip_profile_face[-1], expected, rtol=1e-6)
+
+  def test_shape_parameters(self):
+    """Concentric circles have zero triangularity and unit elongation."""
+    geo = tokamaker.TokaMakerConfig(
+        fsa_profiles=_circular_get_fsa()
+    ).build_geometry()
+    np.testing.assert_allclose(geo.delta_face, 0.0, atol=1e-12)
+    np.testing.assert_allclose(geo.elongation_face, 1.0, rtol=1e-12)
+
+  def test_collapsed_surface_takes_shape_from_its_neighbours(self):
+    """A surface that failed to trace must not make the shape non-finite."""
+    fsa = _circular_get_fsa()
+    for key in ('R_min', 'R_max', 'Z_min', 'Z_max'):
+      fsa[key][0] = _R_MAJOR if key.startswith('R') else 0.0  # positive, but a point
+    geo = tokamaker.TokaMakerConfig(fsa_profiles=fsa).build_geometry()
+    self.assertTrue(np.all(np.isfinite(geo.elongation_face)))
+    self.assertTrue(np.all(np.isfinite(geo.delta_face)))
+    np.testing.assert_allclose(geo.delta_face, 0.0, atol=1e-12)
+    np.testing.assert_allclose(geo.elongation_face, 1.0, rtol=1e-12)
+
+  def test_untraced_surface_raises(self):
+    """A zeroed extremum must be rejected, not carried into R_in / R_out."""
+    fsa = _circular_get_fsa()
+    fsa['R_max'][40] = 0.0
+    with self.assertRaisesRegex(ValueError, 'did not trace'):
+      tokamaker.TokaMakerConfig(fsa_profiles=fsa).build_geometry()
+
+  def test_collapsed_boundary_surface_raises(self):
+    """The boundary surface normalizes the grid, so it has no fallback."""
+    fsa = _circular_get_fsa()
+    fsa['R_min'][-1] = fsa['R_max'][-1]
+    with self.assertRaisesRegex(ValueError, 'outermost traced flux surface'):
+      tokamaker.TokaMakerConfig(fsa_profiles=fsa).build_geometry()
+
+  def test_fully_degenerate_equilibrium_raises(self):
+    fsa = _circular_get_fsa()
+    fsa['R_min'] = fsa['R_max'].copy()
+    with self.assertRaisesRegex(ValueError, 'Every traced flux surface'):
+      tokamaker.TokaMakerConfig(fsa_profiles=fsa).build_geometry()
+
+  def test_on_axis_values_are_prescribed(self):
+    """No surface can be traced on axis, so TORAX prescribes the axis row."""
+    geo = tokamaker.TokaMakerConfig(
+        fsa_profiles=_circular_get_fsa()
+    ).build_geometry()
+    # The poloidal field vanishes on axis, so B is purely toroidal there.
+    np.testing.assert_allclose(
+        geo.gm5_face[0], (_R_MAJOR * _B_0 / _R_MAJOR) ** 2, rtol=1e-12
+    )
+    np.testing.assert_allclose(geo.Ip_profile_face[0], 0.0, atol=1e-12)
+    np.testing.assert_allclose(geo.R_in_face[0], _R_MAJOR, rtol=1e-12)
+    np.testing.assert_allclose(geo.R_out_face[0], _R_MAJOR, rtol=1e-12)
+
+  def test_reversed_toroidal_field(self):
+    """F0 sets the field direction, which TORAX tracks only as a magnitude."""
+    fsa = _circular_get_fsa()
+    reversed_fsa = fsa | {
+        'F': -fsa['F'],
+        'F_axis': -fsa['F_axis'],
+        'F0': -fsa['F0'],
+    }
+    geo = tokamaker.TokaMakerConfig(fsa_profiles=fsa).build_geometry()
+    reversed_geo = tokamaker.TokaMakerConfig(
+        fsa_profiles=reversed_fsa
+    ).build_geometry()
+    np.testing.assert_allclose(reversed_geo.B_0, _B_0, rtol=1e-12)
+    for field in ('vpr', 'g0', 'g1', 'g2', 'g3', 'Phi', 'psi', 'F_face'):
+      np.testing.assert_allclose(
+          getattr(reversed_geo, field),
+          getattr(geo, field),
+          err_msg=f'Field "{field}" mismatch.',
+      )
+
+  def test_config_round_trips_through_json(self):
+    """The config must serialize, since every output write dumps it to JSON."""
+    config = pydantic_model.Geometry.from_dict({
+        'geometry_type': 'tokamaker',
+        'n_rho': 25,
+        'fsa_profiles': _circular_get_fsa(),
+    })
+    restored = pydantic_model.Geometry.model_validate_json(
+        config.model_dump_json()
+    )
+    geo, geo_restored = (
+        config.build_provider(0.0),
+        restored.build_provider(0.0),
+    )
+    for field in ('vpr', 'g0', 'g1', 'g2', 'g3', 'psi', 'Ip_profile_face'):
+      np.testing.assert_allclose(
+          getattr(geo, field),
+          getattr(geo_restored, field),
+          err_msg=f'Field "{field}" mismatch.',
+      )
+
+  def test_time_dependent_geometry_configs(self):
+    """Equilibria at several times are interpolated by the standard provider."""
+    config = pydantic_model.Geometry.from_dict({
+        'geometry_type': 'tokamaker',
+        'n_rho': 25,
+        'geometry_configs': {
+            0.0: {'fsa_profiles': _circular_get_fsa(a_minor=2.0)},
+            1.0: {'fsa_profiles': _circular_get_fsa(a_minor=2.2)},
+        },
+    })
+    provider = config.build_provider
+    np.testing.assert_allclose(provider(0.0).a_minor, 2.0, rtol=1e-12)
+    np.testing.assert_allclose(provider(1.0).a_minor, 2.2, rtol=1e-12)
+    np.testing.assert_allclose(provider(0.5).a_minor, 2.1, rtol=1e-12)
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/torax/_src/geometry/tokamaker.py
+++ b/torax/_src/geometry/tokamaker.py
@@ -1,0 +1,333 @@
+# Copyright 2026 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Functions for loading and representing a TokaMaker geometry."""
+from typing import Annotated, Any, Literal
+
+import numpy as np
+import pydantic
+import scipy
+from torax._src import constants
+from torax._src.geometry import base
+from torax._src.geometry import geometry
+from torax._src.geometry import standard_geometry
+from torax._src.torax_pydantic import torax_pydantic
+import typing_extensions
+
+# pylint: disable=invalid-name
+
+# Maps `TokaMaker_equilibrium.get_fsa()` keys onto field names of
+# `TokaMakerEquilibrium`.
+_GET_FSA_KEY_MAP = {
+    'psi': 'psi',
+    'q': 'q',
+    'F': 'F',
+    '<1/R>': 'flux_surf_avg_1_over_R',
+    '<1/R^2>': 'flux_surf_avg_1_over_R2',
+    'dV/dPsi': 'dV_dpsi',
+    '<|grad psi|>': 'flux_surf_avg_grad_psi',
+    '<|grad psi|^2>': 'flux_surf_avg_grad_psi2',
+    '<Bp^2>': 'flux_surf_avg_Bp2',
+    '<1/B^2>': 'flux_surf_avg_1_over_B2',
+    'R_min': 'R_min',
+    'R_max': 'R_max',
+    'Z_min': 'Z_min',
+    'Z_max': 'Z_max',
+    'R_at_Zmin': 'R_at_Zmin',
+    'R_at_Zmax': 'R_at_Zmax',
+    'psi_axis': 'psi_axis',
+    'R_axis': 'R_axis',
+    'Z_axis': 'Z_axis',
+    'F_axis': 'F_axis',
+    'F0': 'F0',
+}
+
+
+class TokaMakerEquilibrium(torax_pydantic.BaseModelFrozen):
+  """Flux surface averaged profiles extracted from a TokaMaker equilibrium.
+
+  Constructed from the dict of profiles returned by
+  ``TokaMaker_equilibrium.get_fsa()``, whose keys are mapped onto the attributes
+  of this class by `_GET_FSA_KEY_MAP`.
+
+  Attributes:
+    psi: Poloidal flux [Wb/rad]
+    q: Safety factor [dimensionless]
+    F: Toroidal field flux function F = R*B_phi [m T]
+    flux_surf_avg_1_over_R: <1/R> [m^-1]
+    flux_surf_avg_1_over_R2: <1/R^2> [m^-2]
+    dV_dpsi: dV/dpsi [m^3 (Wb/rad)^-1]
+    flux_surf_avg_grad_psi: <|grad psi|> [Wb rad^-1 m^-1]
+    flux_surf_avg_grad_psi2: <|grad psi|^2> [Wb^2 rad^-2 m^-2]
+    flux_surf_avg_Bp2: <Bp^2> [T^2]
+    flux_surf_avg_1_over_B2: <1/B^2> [T^-2]
+    R_min: Minimum major radius of each flux surface [m]
+    R_max: Maximum major radius of each flux surface [m]
+    Z_min: Minimum height of each flux surface [m]
+    Z_max: Maximum height of each flux surface [m]
+    R_at_Zmin: Major radius at ``Z_min`` [m]
+    R_at_Zmax: Major radius at ``Z_max`` [m]
+    psi_axis: Poloidal flux on the magnetic axis [Wb/rad]
+    R_axis: Major radius of the magnetic axis [m]
+    Z_axis: Height of the magnetic axis [m]
+    F_axis: ``F`` on the magnetic axis [m T]
+    F0: Vacuum toroidal field flux function [m T]
+  """
+
+  psi: torax_pydantic.NumpyArray1D
+  q: torax_pydantic.NumpyArray1D
+  F: torax_pydantic.NumpyArray1D
+  flux_surf_avg_1_over_R: torax_pydantic.NumpyArray1D
+  flux_surf_avg_1_over_R2: torax_pydantic.NumpyArray1D
+  dV_dpsi: torax_pydantic.NumpyArray1D
+  flux_surf_avg_grad_psi: torax_pydantic.NumpyArray1D
+  flux_surf_avg_grad_psi2: torax_pydantic.NumpyArray1D
+  flux_surf_avg_Bp2: torax_pydantic.NumpyArray1D
+  flux_surf_avg_1_over_B2: torax_pydantic.NumpyArray1D
+  R_min: torax_pydantic.NumpyArray1D
+  R_max: torax_pydantic.NumpyArray1D
+  Z_min: torax_pydantic.NumpyArray1D
+  Z_max: torax_pydantic.NumpyArray1D
+  R_at_Zmin: torax_pydantic.NumpyArray1D
+  R_at_Zmax: torax_pydantic.NumpyArray1D
+  psi_axis: float
+  R_axis: torax_pydantic.Meter
+  Z_axis: float
+  F_axis: float
+  F0: float
+
+  @pydantic.model_validator(mode='before')
+  @classmethod
+  def _conform_get_fsa_dict(cls, data: Any) -> Any:
+    """Renames `get_fsa()` keys."""
+    if not isinstance(data, dict):
+      return data
+    return {
+        _GET_FSA_KEY_MAP.get(key, key): value
+        for key, value in data.items()
+        if key in _GET_FSA_KEY_MAP or key in cls.model_fields
+    }
+
+  @pydantic.model_validator(mode='after')
+  def _validate_profiles(self) -> typing_extensions.Self:
+    lengths = {
+        name: len(getattr(self, name))
+        for name in type(self).model_fields
+        if isinstance(getattr(self, name), np.ndarray)
+    }
+    if len(set(lengths.values())) != 1:
+      raise ValueError(f'Profiles have inconsistent lengths: {lengths}')
+    if len(self.psi) < 2:
+      raise ValueError('At least 2 flux surfaces are required.')
+    return self
+
+
+class TokaMakerConfig(base.BaseGeometryConfig):
+  """Pydantic model for the TokaMaker geometry.
+
+  The flux surface grid is set by the ``get_fsa()`` call, not by this config.
+  The outermost sampled surface becomes rho_norm = 1, so ``psi_pad=0.01`` plays
+  the role of ``last_surface_factor=0.99`` in the EQDSK geometry. Sample
+  uniformly in sqrt(psi_norm) rather than psi_norm, since rho_norm scales as
+  sqrt(psi_norm) near the axis and a psi_norm-uniform grid is coarse there.
+
+  Attributes:
+    geometry_type: Always set to 'tokamaker'.
+    Ip_from_parameters: Toggles whether total plasma current is read from the
+      configuration file, or from the equilibrium. If True, then the `psi`
+      calculated from the equilibrium is scaled to match the desired `I_p`.
+    fsa_profiles: Flux surface profiles, as returned by
+      ``TokaMaker_equilibrium.get_fsa()``.
+  """
+
+  geometry_type: Annotated[
+      Literal['tokamaker'], torax_pydantic.TIME_INVARIANT
+  ] = 'tokamaker'
+  Ip_from_parameters: Annotated[bool, torax_pydantic.TIME_INVARIANT] = True
+  fsa_profiles: TokaMakerEquilibrium
+
+  def build_geometry(self) -> standard_geometry.StandardGeometry:
+    intermediates = _construct_intermediates_from_tokamaker(
+        equilibrium=self.fsa_profiles,
+        Ip_from_parameters=self.Ip_from_parameters,
+        face_centers=self.get_face_centers(),
+        hires_factor=self.hires_factor,
+    )
+    return standard_geometry.build_standard_geometry(intermediates)
+
+
+def _construct_intermediates_from_tokamaker(
+    equilibrium: TokaMakerEquilibrium,
+    Ip_from_parameters: bool,
+    face_centers: np.ndarray,
+    hires_factor: int,
+) -> standard_geometry.StandardGeometryIntermediates:
+  """Constructs a StandardGeometryIntermediates from TokaMaker profiles.
+
+  Converts TokaMaker's conventions (psi in Wb/rad, so Bp = |grad psi| / R) to
+  the COCOS 11 (psi in Wb, so Bp = |grad psi| / 2*pi*R),
+  i.e. psi_11 = 2*pi*psi_TM, and prepends the magnetic axis, where no flux
+  surface can be traced.
+
+  Args:
+    equilibrium: Flux surface profiles from ``TokaMaker_equilibrium.get_fsa()``.
+    Ip_from_parameters: If True, the Ip is taken from the parameters and the
+      values in the Geometry are rescaled to match the new Ip.
+    face_centers: Array of face center coordinates in normalized rho (0 to 1).
+    hires_factor: Grid refinement factor for poloidal flux <--> plasma current
+      calculations.
+
+  Returns:
+    A StandardGeometryIntermediates instance, to be passed to
+    `build_standard_geometry`.
+  """
+  eq = equilibrium
+  # On axis a flux surface degenerates to a point, so the poloidal field and
+  # its flux surface averages vanish and B is purely toroidal.
+  Btor_axis = eq.F_axis / eq.R_axis
+  prepend = lambda axis_value, profile: np.concatenate(
+      [np.array([axis_value]), profile]
+  )
+
+  psi = 2 * np.pi * prepend(eq.psi_axis, eq.psi)
+  F = prepend(eq.F_axis, eq.F)
+  # dV/dpsi = 2*pi*oint(dl/Bp), and Bp is convention independent.
+  int_dl_over_Bp = prepend(0.0, np.abs(eq.dV_dpsi) / (2 * np.pi))
+  flux_surf_avg_1_over_R = prepend(1.0 / eq.R_axis, eq.flux_surf_avg_1_over_R)
+  flux_surf_avg_1_over_R2 = prepend(
+      1.0 / eq.R_axis**2, eq.flux_surf_avg_1_over_R2
+  )
+  flux_surf_avg_grad_psi = prepend(0.0, 2 * np.pi * eq.flux_surf_avg_grad_psi)
+  flux_surf_avg_grad_psi2 = prepend(
+      0.0, 4 * np.pi**2 * eq.flux_surf_avg_grad_psi2
+  )
+  flux_surf_avg_grad_psi2_over_R2 = prepend(
+      0.0, 4 * np.pi**2 * eq.flux_surf_avg_Bp2
+  )
+  # F is constant on a flux surface, so <B^2> follows exactly from <Bp^2>.
+  flux_surf_avg_B2 = prepend(
+      Btor_axis**2, eq.flux_surf_avg_Bp2 + eq.F**2 * eq.flux_surf_avg_1_over_R2
+  )
+  flux_surf_avg_1_over_B2 = prepend(
+      1.0 / Btor_axis**2, eq.flux_surf_avg_1_over_B2
+  )
+
+  # Enclosed toroidal current from Ampere's law on a flux surface:
+  # mu_0 I = oint(B_p dl) = <B_p^2> oint(dl/B_p).
+  Ip_profile = (
+      prepend(0.0, eq.flux_surf_avg_Bp2)
+      * int_dl_over_Bp
+      / constants.CONSTANTS.mu_0
+  )
+
+  # q = dPhi/dpsi in COCOS 11.
+  q = prepend(eq.q[0], eq.q)
+  Phi = scipy.integrate.cumulative_trapezoid(y=q, x=psi, initial=0.0)
+
+  # R extrema bound the plasma, so a non-positive one means the tracer left the
+  # entry unwritten; it would otherwise reach R_in / R_out and later give NaNs.
+  unwritten = np.flatnonzero((eq.R_min <= 0.0) | (eq.R_max <= 0.0))
+  if unwritten.size:
+    i = unwritten[0]
+    raise ValueError(
+        f'Flux surface {i} of {len(eq.R_min)} (psi = {eq.psi[i]} Wb/rad) has a'
+        f' non-positive major radius extremum (R_min = {eq.R_min[i]}, R_max ='
+        f' {eq.R_max[i]}); it did not trace.'
+    )
+
+  R_in = prepend(eq.R_axis, eq.R_min)
+  R_out = prepend(eq.R_axis, eq.R_max)
+  a_minor_local = (eq.R_max - eq.R_min) / 2.0
+  R_geo_local = (eq.R_max + eq.R_min) / 2.0
+
+  # A traced surface can still collapse to a point, most often the innermost
+  # one, where a zero minor radius makes the shape parameters non-finite.
+  resolved = a_minor_local > 0.0
+  if not resolved.any():
+    raise ValueError(
+        'Every traced flux surface has zero minor radius indicating the ' \
+        'TokaMaker equilibrium is degenerate.'
+    )
+  index = np.arange(len(a_minor_local))
+  fill = lambda profile: (
+      profile
+      if resolved.all()
+      else np.interp(index, index[resolved], profile)
+  )
+  a_resolved = a_minor_local[resolved]
+  elongation = fill(
+      (eq.Z_max[resolved] - eq.Z_min[resolved]) / (2.0 * a_resolved)
+  )
+  delta_upper_face = fill(
+      (R_geo_local[resolved] - eq.R_at_Zmax[resolved]) / a_resolved
+  )
+  delta_lower_face = fill(
+      (R_geo_local[resolved] - eq.R_at_Zmin[resolved]) / a_resolved
+  )
+  # The axis is a point, so it takes the shape of the innermost traced surface.
+  elongation = prepend(elongation[0], elongation)
+  delta_upper_face = prepend(delta_upper_face[0], delta_upper_face)
+  delta_lower_face = prepend(delta_lower_face[0], delta_lower_face)
+
+  R_major = (eq.R_max[-1] + eq.R_min[-1]) / 2.0
+  a_minor = (eq.R_max[-1] - eq.R_min[-1]) / 2.0
+  if a_minor <= 0.0:
+    raise ValueError(
+        'The outermost traced flux surface has zero minor radius'
+        f' (R_min = R_max = {eq.R_max[-1]}); it cannot define the plasma'
+        ' boundary.'
+    )
+  # F0 carries the sign of the toroidal field direction, which TORAX does not
+  # track: B_0 enters as a magnitude, e.g. rho = sqrt(Phi_b/(pi*B_0)).
+  B_0 = np.abs(eq.F0) / R_major
+
+  # dV/drho_norm, from dV/dpsi and dpsi/drho_norm = 2*Phi_b*rho_norm/q.
+  rhon = np.sqrt(np.abs(Phi / Phi[-1]))
+  vpr = 4 * np.pi * np.abs(Phi[-1]) * rhon / (F * flux_surf_avg_1_over_R2)
+
+  return standard_geometry.StandardGeometryIntermediates(
+      geometry_type=geometry.GeometryType.TOKAMAKER,
+      Ip_from_parameters=Ip_from_parameters,
+      R_major=np.array(R_major),
+      a_minor=np.array(a_minor),
+      B_0=np.array(B_0),
+      psi=psi,
+      Ip_profile=Ip_profile,
+      Phi=Phi,
+      R_in=R_in,
+      R_out=R_out,
+      F=F,
+      int_dl_over_Bp=int_dl_over_Bp,
+      flux_surf_avg_1_over_R=flux_surf_avg_1_over_R,
+      flux_surf_avg_1_over_R2=flux_surf_avg_1_over_R2,
+      flux_surf_avg_grad_psi=flux_surf_avg_grad_psi,
+      flux_surf_avg_grad_psi2=flux_surf_avg_grad_psi2,
+      flux_surf_avg_grad_psi2_over_R2=flux_surf_avg_grad_psi2_over_R2,
+      flux_surf_avg_B2=flux_surf_avg_B2,
+      flux_surf_avg_1_over_B2=flux_surf_avg_1_over_B2,
+      delta_upper_face=delta_upper_face,
+      delta_lower_face=delta_lower_face,
+      elongation=elongation,
+      vpr=vpr,
+      face_centers=face_centers,
+      hires_factor=hires_factor,
+      # The outermost sampled surface is the LCFS, so no diverted edge model.
+      diverted=None,
+      connection_length_target=None,
+      connection_length_divertor=None,
+      angle_of_incidence_target=None,
+      R_OMP=None,
+      R_target=None,
+      B_pol_OMP=None,
+      z_magnetic_axis=np.array(eq.Z_axis),
+  )


### PR DESCRIPTION
This PR adds the ability to pass geometry information from [TokaMaker](https://github.com/openfusiontoolkit/openfusiontoolkit) directly (i.e. in memory) to TORAX via the 'tokamaker' geometry mode. The geometry information is calculated by TokaMaker (using the new `get_fsa()` function) and then passed to TORAX as a dict of arrays. 

This geometry mode bypasses the saving and reading of `eqdsk` files, which is especially useful for the TokaMaker+TORAX pulse design workflow (which currently requires saving and loading hundreds of `eqdsk` files). 

This does not add a dependency for TokaMaker (or OFT) to TORAX. The geometry inputs are simply floats and NumPy arrays. The new `tokamaker_test.py` added for this geometry type creates TokaMaker-like dict of arrays from a dummy cylindrical geometry, not requiring TokaMaker.