### PR TITLE
Fix Lithium atomic mass in ion properties

### DIFF
--- a/torax/_src/constants.py
+++ b/torax/_src/constants.py
@@ -109,7 +109,7 @@ ION_PROPERTIES: Final[tuple[IonProperties, ...]] = (
         symbol='He4', name='Helium-4', A=4.0026, Z=2.0, E_ionization=24.587
     ),
     IonProperties(
-        symbol='Li', name='Lithium', A=5.3917, Z=3.0, E_ionization=5.392
+        symbol='Li', name='Lithium', A=6.94, Z=3.0, E_ionization=5.392
     ),
     IonProperties(
         symbol='Be', name='Beryllium', A=9.0122, Z=4.0, E_ionization=9.323


### PR DESCRIPTION
## Summary

The Lithium `IonProperties` entry in `torax/_src/constants.py` has `A=5.3917`, but `5.3917` is Lithium's first ionization energy in eV — not its atomic mass. The `E_ionization` field already carries `5.392`; the `A` field should be the atomic mass, which for Lithium is 6.94 amu.

`A` is consumed in `torax/_src/core_profiles/getters.py` (the `A_avg` / `A_avg_face` average-ion-mass calculation) and propagates into transport coefficients. Any configuration using lithium as an impurity therefore gets a slightly-wrong average ion mass.

## Change

- `torax/_src/constants.py`: `A=5.3917` → `A=6.94` for the Lithium entry.

## Verification

- Confirmed `5.3917` appears nowhere else in the repo and no test asserts the old value.
- All other entries in the table use standard atomic weights (H 1.008, He 4.0026, C 12.011, ...), so 6.94 is consistent with the table's convention (NIST standard atomic weight).