### PR TITLE
Preserve Pereverzev transport under adaptive pedestal scaling

### DIFF
--- a/torax/_src/pedestal_model/pedestal_model_output.py
+++ b/torax/_src/pedestal_model/pedestal_model_output.py
@@ -25,8 +25,15 @@ from torax._src import state
 from torax._src.geometry import geometry
 from torax._src.internal_boundary_conditions import internal_boundary_conditions as internal_boundary_conditions_lib
 from torax._src.pedestal_model import runtime_params as pedestal_runtime_params_lib
+from torax._src.transport_model import pereverzev as pereverzev_lib
 
 # pylint: disable=invalid-name
+
+
+_PEREVERZEV_FIELDS = frozenset(
+    field.name
+    for field in dataclasses.fields(pereverzev_lib.PereverzevTransport)
+)
 
 
 @jax.tree_util.register_dataclass
@@ -240,11 +247,11 @@ class PedestalModelOutput:
   ) -> state.CoreTransport:
     """Modify transport coefficients in the entire pedestal region.
 
-    Scales the turbulent and Pereverzev transport coefficients in the pedestal
-    region by the multipliers in the pedestal model output. This will also scale
-    any components of the transport coefficients that are inherited from the
-    turbulent model, such as ITG, ETG, TEM, Bohm, GyroBohm, etc. Transport
-    coefficients from neoclassical and pedestal transport models are not
+    Scales the turbulent transport coefficients in the pedestal region by the
+    multipliers in the pedestal model output. This will also scale any
+    components of the transport coefficients that are inherited from the
+    turbulent model, such as ITG, ETG, TEM, Bohm, GyroBohm, etc. Numerical
+    Pereverzev-Corrigan and neoclassical transport coefficients are not
     affected.
 
     Args:
@@ -273,14 +280,21 @@ class PedestalModelOutput:
     def multiply_coeff(
         path: jax.tree_util.KeyPath, coeff: array_typing.FloatVectorFace
     ) -> array_typing.FloatVectorFace:
-      """Scale turbulent+Pereverzev transport coefficients in the pedestal."""
+      """Scale turbulent transport coefficients in the pedestal."""
       # Get the variable name of the leaf
-      key = str(path[-1])
+      path_key = path[-1]
+      if not isinstance(path_key, jax.tree_util.GetAttrKey):
+        raise TypeError(f"Expected a CoreTransport field, got {path_key!r}.")
+      key = path_key.name
 
       # Apply the correct multiplier based on the variable name
       # TODO(b/488314338): Improve robustness of applying multipliers to
       # transport coefficients, ideally avoiding string matching.
-      if "neo" in key:
+      if key in _PEREVERZEV_FIELDS:
+        # Pereverzev-Corrigan diffusion and counter-convection are paired to
+        # have zero net flux. Modifying either would break that cancellation.
+        return coeff
+      elif "neo" in key:
         # Neoclassical transport should not be affected by scaling from an
         # ADAPTIVE_TRANSPORT pedestal model.
         return coeff

--- a/torax/_src/pedestal_model/tests/pedestal_model_output_test.py
+++ b/torax/_src/pedestal_model/tests/pedestal_model_output_test.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
 from unittest import mock
 from absl.testing import absltest
+import jax
 from jax import numpy as jnp
 import numpy as np
 from torax._src import state
@@ -22,6 +24,7 @@ from torax._src.geometry import circular_geometry
 from torax._src.geometry import geometry
 from torax._src.pedestal_model import pedestal_model_output
 from torax._src.pedestal_model import runtime_params as pedestal_runtime_params_lib
+from torax._src.transport_model import pereverzev
 
 # pylint: disable=invalid-name
 
@@ -46,6 +49,14 @@ class PedestalModelOutputTest(absltest.TestCase):
             v_e_multiplier=jnp.array(5.0),
         ),
     )
+    self.pedestal_runtime_params = mock.create_autospec(
+        pedestal_runtime_params_lib.RuntimeParams, instance=True
+    )
+    self.pedestal_runtime_params.chi_max = jnp.array(1.0)
+    self.pedestal_runtime_params.D_e_max = jnp.array(1.0)
+    self.pedestal_runtime_params.V_e_max = jnp.array(1.0)
+    self.pedestal_runtime_params.V_e_min = jnp.array(-1.0)
+    self.pedestal_runtime_params.pedestal_top_smoothing_width = jnp.array(0.0)
 
   def test_to_internal_boundary_conditions(self):
     ibc = self.pedestal_model_output.to_internal_boundary_conditions(self.geo)
@@ -76,6 +87,15 @@ class PedestalModelOutputTest(absltest.TestCase):
 
   def test_modify_core_transport_applies_multipliers(self):
     n_face = self.geo.rho_face_norm.shape[0]
+    rho_face = self.geo.rho_face_norm
+    pereverzev_transport = pereverzev.PereverzevTransport(
+        chi_face_ion_pereverzev=30.0 + rho_face,
+        chi_face_el_pereverzev=31.0 + rho_face,
+        full_v_heat_face_ion_pereverzev=-40.0 - rho_face,
+        full_v_heat_face_el_pereverzev=-41.0 - rho_face,
+        d_face_el_pereverzev=15.0 + rho_face,
+        v_face_el_pereverzev=-20.0 + rho_face,
+    )
     core_transport = state.CoreTransport(
         chi_face_ion=jnp.ones(n_face),
         chi_face_el=jnp.ones(n_face),
@@ -99,36 +119,24 @@ class PedestalModelOutputTest(absltest.TestCase):
         D_neo_e=jnp.ones(n_face),
         V_neo_e=jnp.ones(n_face),
         V_neo_ware_e=jnp.ones(n_face),
-        chi_face_ion_pereverzev=jnp.ones(n_face),
-        chi_face_el_pereverzev=jnp.ones(n_face),
-        full_v_heat_face_ion_pereverzev=jnp.ones(n_face),
-        full_v_heat_face_el_pereverzev=jnp.ones(n_face),
-        d_face_el_pereverzev=jnp.ones(n_face),
-        v_face_el_pereverzev=jnp.ones(n_face),
+        **dataclasses.asdict(pereverzev_transport),
     )
 
-    pedestal_runtime_params = mock.create_autospec(
-        pedestal_runtime_params_lib.RuntimeParams, instance=True
+    modify_core_transport = jax.jit(
+        lambda transport: self.pedestal_model_output.modify_core_transport(
+            transport, self.geo, self.pedestal_runtime_params
+        )
     )
-    pedestal_runtime_params.chi_max = jnp.array(1.0)
-    pedestal_runtime_params.D_e_max = jnp.array(1.0)
-    pedestal_runtime_params.V_e_max = jnp.array(1.0)
-    pedestal_runtime_params.V_e_min = jnp.array(-1.0)
-    pedestal_runtime_params.pedestal_top_smoothing_width = jnp.array(0.0)
-
-    modified_core_transport = self.pedestal_model_output.modify_core_transport(
-        core_transport, self.geo, pedestal_runtime_params
-    )
+    modified_core_transport = modify_core_transport(core_transport)
     pedestal_mask = (
         self.geo.rho_face_norm > self.pedestal_model_output.rho_norm_ped_top
     )
 
-    # Check turbulent and Pereverzev transport is scaled correctly.
+    # Check turbulent transport is scaled correctly.
     for field_name in [
         'chi_face_el',
         'chi_face_el_bohm',
         'chi_face_el_gyrobohm',
-        'chi_face_el_pereverzev',
     ]:
       field = getattr(modified_core_transport, field_name)
       np.testing.assert_allclose(
@@ -139,26 +147,19 @@ class PedestalModelOutputTest(absltest.TestCase):
         'chi_face_ion',
         'chi_face_ion_bohm',
         'chi_face_ion_gyrobohm',
-        'chi_face_ion_pereverzev',
     ]:
       field = getattr(modified_core_transport, field_name)
       np.testing.assert_allclose(
           field,
           jnp.where(pedestal_mask, 3.0, 1.0),
       )
-    for field_name in [
-        'd_face_el',
-        'd_face_el_pereverzev',
-    ]:
+    for field_name in ['d_face_el']:
       field = getattr(modified_core_transport, field_name)
       np.testing.assert_allclose(
           field,
           jnp.where(pedestal_mask, 4.0, 1.0),
       )
-    for field_name in [
-        'v_face_el',
-        'v_face_el_pereverzev',
-    ]:
+    for field_name in ['v_face_el']:
       field = getattr(modified_core_transport, field_name)
       np.testing.assert_allclose(
           field,
@@ -186,6 +187,14 @@ class PedestalModelOutputTest(absltest.TestCase):
         modified_core_transport.V_neo_ware_e,
         core_transport.V_neo_ware_e,
     )
+
+    # Numerical Pereverzev-Corrigan transport is not scaled or clipped.
+    for field in dataclasses.fields(pereverzev.PereverzevTransport):
+      with self.subTest(field=field.name):
+        np.testing.assert_array_equal(
+            getattr(modified_core_transport, field.name),
+            getattr(core_transport, field.name),
+        )
 
   def test_to_internal_boundary_conditions_tanh_profiles(self):
     """Tests mtanh-shaped IBC when pedestal_profile_form=MTANH."""

--- a/torax/_src/transport_model/tests/transport_model_test.py
+++ b/torax/_src/transport_model/tests/transport_model_test.py
@@ -35,9 +35,11 @@ from torax._src.torax_pydantic import model_config
 from torax._src.torax_pydantic import torax_pydantic
 from torax._src.transport_model import component
 from torax._src.transport_model import enums
+from torax._src.transport_model import pereverzev
 from torax._src.transport_model import pydantic_model_base as transport_pydantic_model_base
 from torax._src.transport_model import register_model
 from torax._src.transport_model import runtime_params as transport_runtime_params_lib
+from torax._src.transport_model import transport_coefficients_builder
 from torax._src.transport_model import transport_model
 
 
@@ -359,6 +361,74 @@ class TransportMaskingTest(parameterized.TestCase):
 
 
 class TransportModelTest(absltest.TestCase):
+
+  def test_adaptive_transport_preserves_pereverzev_transport(self):
+    """Adaptive suppression leaves numerical PC transport unchanged."""
+    config = default_configs.get_default_config_dict()
+    config['solver'] = {
+        'chi_pereverzev': 30.0,
+        'D_pereverzev': 15.0,
+    }
+    config['pedestal'] = {
+        'model_name': 'set_T_ped_n_ped',
+        'set_pedestal': True,
+        'mode': 'ADAPTIVE_TRANSPORT',
+    }
+    torax_config = model_config.ToraxConfig.from_dict(config)
+    models = torax_config.build_models()
+    runtime_params = build_runtime_params.RuntimeParamsProvider.from_config(
+        torax_config
+    )(t=0.0)
+    geo = torax_config.geometry.build_provider(t=0.0)
+    core_profiles = initialization.initial_core_profiles(
+        runtime_params,
+        geo,
+        models.source_models,
+        models.neoclassical_models,
+    )
+    pedestal_output = pedestal_model_output_lib.PedestalModelOutput(
+        rho_norm_ped_top=0.5,
+        T_i_ped=1.0,
+        T_e_ped=1.0,
+        n_e_ped=1e19,
+        transport_multipliers=pedestal_model_output_lib.TransportMultipliers(
+            chi_e_multiplier=0.1,
+            chi_i_multiplier=0.1,
+            D_e_multiplier=0.1,
+            v_e_multiplier=0.1,
+        ),
+    )
+    transition_state = dataclasses.replace(
+        pedestal_transition_state_lib.PedestalTransitionState.empty_L_mode(),
+        pedestal_model_output=pedestal_output,
+    )
+
+    coeffs = transport_coefficients_builder.calculate_all_transport_coeffs(
+        models.transport_model,
+        models.neoclassical_models,
+        runtime_params,
+        geo,
+        core_profiles,
+        transition_state,
+        use_pereverzev=True,
+    )
+
+    two_point_mask = pedestal_output.get_two_point_face_mask(
+        geo, set_pedestal=runtime_params.pedestal.set_pedestal
+    )
+    raw_pereverzev = pereverzev.calculate_pereverzev_transport(
+        runtime_params,
+        geo,
+        core_profiles,
+        two_point_mask,
+    )
+    for field in dataclasses.fields(pereverzev.PereverzevTransport):
+      with self.subTest(field=field.name):
+        np.testing.assert_allclose(
+            getattr(coeffs, field.name),
+            getattr(raw_pereverzev, field.name),
+            rtol=1e-12,
+        )
 
   def test_combining(self):
     config = default_configs.get_default_config_dict()

--- a/torax/_src/transport_model/transport_coefficients_builder.py
+++ b/torax/_src/transport_model/transport_coefficients_builder.py
@@ -148,8 +148,9 @@ def calculate_all_transport_coeffs(
       **dataclasses.asdict(pereverzev_transport_coeffs),
   )
 
-  # Modify the turbulent + Pereverzev transport coefficients if the pedestal
-  # model is in ADAPTIVE_TRANSPORT mode.
+  # Modify the turbulent transport coefficients if the pedestal model is in
+  # ADAPTIVE_TRANSPORT mode. Pereverzev-Corrigan terms are numerical
+  # stabilization and are kept unchanged so their paired fluxes cancel.
   if (
       runtime_params.pedestal.mode
       == pedestal_runtime_params_lib.Mode.ADAPTIVE_TRANSPORT


### PR DESCRIPTION
## Summary

- keep Pereverzev-Corrigan numerical transport coefficients outside adaptive pedestal clipping, scaling, and smoothing
- derive protected fields from the PereverzevTransport dataclass so all six paired terms remain consistent
- update the existing modifier test and add a JIT production-path regression comparing assembled coefficients with raw Pereverzev transport

## Context

Pereverzev diffusion and counter-convection terms are constructed as zero-net-flux pairs for numerical stabilization. Adaptive pedestal processing previously modified the Pereverzev chi, D, and particle V fields while leaving both full_v_heat counter-convection fields unchanged. Later clipping and pedestal-top smoothing amplified this mismatch.

## Validation

- 87 tests and 35 subtests passed with TORAX runtime assertions enabled
- focused pylint check: 10.00/10
- 60 s adaptive L-H simulation: 945 to 87 accepted steps; median accepted timestep 0.015625 s to 1.0 s; maximum normalized Pereverzev pair defect 0.973 to 1.9e-16