### PR TITLE
Fix Pereverzev transport coefficients modified under adaptive pedestal scaling

### DIFF
--- a/torax/_src/pedestal_model/pedestal_model_output.py
+++ b/torax/_src/pedestal_model/pedestal_model_output.py
@@ -25,8 +25,15 @@ from torax._src import state
 from torax._src.geometry import geometry
 from torax._src.internal_boundary_conditions import internal_boundary_conditions as internal_boundary_conditions_lib
 from torax._src.pedestal_model import runtime_params as pedestal_runtime_params_lib
+from torax._src.transport_model import pereverzev as pereverzev_lib
 
 # pylint: disable=invalid-name
+
+
+_PEREVERZEV_FIELDS = frozenset(
+    field.name
+    for field in dataclasses.fields(pereverzev_lib.PereverzevTransport)
+)
 
 
 @jax.tree_util.register_dataclass
@@ -240,11 +247,11 @@ class PedestalModelOutput:
   ) -> state.CoreTransport:
     """Modify transport coefficients in the entire pedestal region.
 
-    Scales the turbulent and Pereverzev transport coefficients in the pedestal
-    region by the multipliers in the pedestal model output. This will also scale
-    any components of the transport coefficients that are inherited from the
-    turbulent model, such as ITG, ETG, TEM, Bohm, GyroBohm, etc. Transport
-    coefficients from neoclassical and pedestal transport models are not
+    Scales the turbulent transport coefficients in the pedestal region by the
+    multipliers in the pedestal model output. This will also scale any
+    components of the transport coefficients that are inherited from the
+    turbulent model, such as ITG, ETG, TEM, Bohm, GyroBohm, etc. Numerical
+    Pereverzev-Corrigan and neoclassical transport coefficients are not
     affected.
 
     Args:
@@ -273,14 +280,21 @@ class PedestalModelOutput:
     def multiply_coeff(
         path: jax.tree_util.KeyPath, coeff: array_typing.FloatVectorFace
     ) -> array_typing.FloatVectorFace:
-      """Scale turbulent+Pereverzev transport coefficients in the pedestal."""
+      """Scale turbulent transport coefficients in the pedestal."""
       # Get the variable name of the leaf
-      key = str(path[-1])
+      path_key = path[-1]
+      if not isinstance(path_key, jax.tree_util.GetAttrKey):
+        raise TypeError(f"Expected a CoreTransport field, got {path_key!r}.")
+      key = path_key.name
 
       # Apply the correct multiplier based on the variable name
       # TODO(b/488314338): Improve robustness of applying multipliers to
       # transport coefficients, ideally avoiding string matching.
-      if "neo" in key:
+      if key in _PEREVERZEV_FIELDS:
+        # Pereverzev-Corrigan diffusion and counter-convection are paired to
+        # have zero net flux. Modifying either would break that cancellation.
+        return coeff
+      elif "neo" in key:
         # Neoclassical transport should not be affected by scaling from an
         # ADAPTIVE_TRANSPORT pedestal model.
         return coeff

--- a/torax/_src/pedestal_model/pedestal_model_output.py
+++ b/torax/_src/pedestal_model/pedestal_model_output.py
@@ -25,15 +25,8 @@ from torax._src import state
 from torax._src.geometry import geometry
 from torax._src.internal_boundary_conditions import internal_boundary_conditions as internal_boundary_conditions_lib
 from torax._src.pedestal_model import runtime_params as pedestal_runtime_params_lib
-from torax._src.transport_model import pereverzev as pereverzev_lib
 
 # pylint: disable=invalid-name
-
-
-_PEREVERZEV_FIELDS = frozenset(
-    field.name
-    for field in dataclasses.fields(pereverzev_lib.PereverzevTransport)
-)
 
 
 @jax.tree_util.register_dataclass
@@ -282,15 +275,12 @@ class PedestalModelOutput:
     ) -> array_typing.FloatVectorFace:
       """Scale turbulent transport coefficients in the pedestal."""
       # Get the variable name of the leaf
-      path_key = path[-1]
-      if not isinstance(path_key, jax.tree_util.GetAttrKey):
-        raise TypeError(f"Expected a CoreTransport field, got {path_key!r}.")
-      key = path_key.name
+      key = str(path[-1])
 
       # Apply the correct multiplier based on the variable name
       # TODO(b/488314338): Improve robustness of applying multipliers to
       # transport coefficients, ideally avoiding string matching.
-      if key in _PEREVERZEV_FIELDS:
+      if "pereverzev" in key:
         # Pereverzev-Corrigan diffusion and counter-convection are paired to
         # have zero net flux. Modifying either would break that cancellation.
         return coeff

--- a/torax/_src/pedestal_model/tests/pedestal_model_output_test.py
+++ b/torax/_src/pedestal_model/tests/pedestal_model_output_test.py
@@ -144,18 +144,14 @@ class PedestalModelOutputTest(absltest.TestCase):
           field,
           jnp.where(pedestal_mask, 3.0, 1.0),
       )
-    for field_name in ['d_face_el']:
-      field = getattr(modified_core_transport, field_name)
-      np.testing.assert_allclose(
-          field,
-          jnp.where(pedestal_mask, 4.0, 1.0),
-      )
-    for field_name in ['v_face_el']:
-      field = getattr(modified_core_transport, field_name)
-      np.testing.assert_allclose(
-          field,
-          jnp.where(pedestal_mask, 5.0, 1.0),
-      )
+    np.testing.assert_allclose(
+        modified_core_transport.d_face_el,
+        jnp.where(pedestal_mask, 4.0, 1.0),
+    )
+    np.testing.assert_allclose(
+        modified_core_transport.v_face_el,
+        jnp.where(pedestal_mask, 5.0, 1.0),
+    )
 
     # Check neoclassical transport is not affected.
     np.testing.assert_allclose(  # pyrefly: ignore[no-matching-overload]

--- a/torax/_src/pedestal_model/tests/pedestal_model_output_test.py
+++ b/torax/_src/pedestal_model/tests/pedestal_model_output_test.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
 from unittest import mock
 from absl.testing import absltest
+import jax
 from jax import numpy as jnp
 import numpy as np
 from torax._src import state
@@ -22,6 +24,7 @@ from torax._src.geometry import circular_geometry
 from torax._src.geometry import geometry
 from torax._src.pedestal_model import pedestal_model_output
 from torax._src.pedestal_model import runtime_params as pedestal_runtime_params_lib
+from torax._src.transport_model import pereverzev
 
 # pylint: disable=invalid-name
 
@@ -46,6 +49,14 @@ class PedestalModelOutputTest(absltest.TestCase):
             v_e_multiplier=jnp.array(5.0),
         ),
     )
+    self.pedestal_runtime_params = mock.create_autospec(
+        pedestal_runtime_params_lib.RuntimeParams, instance=True
+    )
+    self.pedestal_runtime_params.chi_max = jnp.array(1.0)
+    self.pedestal_runtime_params.D_e_max = jnp.array(1.0)
+    self.pedestal_runtime_params.V_e_max = jnp.array(1.0)
+    self.pedestal_runtime_params.V_e_min = jnp.array(-1.0)
+    self.pedestal_runtime_params.pedestal_top_smoothing_width = jnp.array(0.0)
 
   def test_to_internal_boundary_conditions(self):
     ibc = self.pedestal_model_output.to_internal_boundary_conditions(self.geo)
@@ -76,6 +87,15 @@ class PedestalModelOutputTest(absltest.TestCase):
 
   def test_modify_core_transport_applies_multipliers(self):
     n_face = self.geo.rho_face_norm.shape[0]
+    rho_face = self.geo.rho_face_norm
+    pereverzev_transport = pereverzev.PereverzevTransport(
+        chi_face_ion_pereverzev=30.0 + rho_face,
+        chi_face_el_pereverzev=31.0 + rho_face,
+        full_v_heat_face_ion_pereverzev=-40.0 - rho_face,
+        full_v_heat_face_el_pereverzev=-41.0 - rho_face,
+        d_face_el_pereverzev=15.0 + rho_face,
+        v_face_el_pereverzev=-20.0 + rho_face,
+    )
     core_transport = state.CoreTransport(
         chi_face_ion=jnp.ones(n_face),
         chi_face_el=jnp.ones(n_face),
@@ -99,36 +119,24 @@ class PedestalModelOutputTest(absltest.TestCase):
         D_neo_e=jnp.ones(n_face),
         V_neo_e=jnp.ones(n_face),
         V_neo_ware_e=jnp.ones(n_face),
-        chi_face_ion_pereverzev=jnp.ones(n_face),
-        chi_face_el_pereverzev=jnp.ones(n_face),
-        full_v_heat_face_ion_pereverzev=jnp.ones(n_face),
-        full_v_heat_face_el_pereverzev=jnp.ones(n_face),
-        d_face_el_pereverzev=jnp.ones(n_face),
-        v_face_el_pereverzev=jnp.ones(n_face),
+        **dataclasses.asdict(pereverzev_transport),
     )
 
-    pedestal_runtime_params = mock.create_autospec(
-        pedestal_runtime_params_lib.RuntimeParams, instance=True
+    modify_core_transport = jax.jit(
+        lambda transport: self.pedestal_model_output.modify_core_transport(
+            transport, self.geo, self.pedestal_runtime_params
+        )
     )
-    pedestal_runtime_params.chi_max = jnp.array(1.0)
-    pedestal_runtime_params.D_e_max = jnp.array(1.0)
-    pedestal_runtime_params.V_e_max = jnp.array(1.0)
-    pedestal_runtime_params.V_e_min = jnp.array(-1.0)
-    pedestal_runtime_params.pedestal_top_smoothing_width = jnp.array(0.0)
-
-    modified_core_transport = self.pedestal_model_output.modify_core_transport(
-        core_transport, self.geo, pedestal_runtime_params
-    )
+    modified_core_transport = modify_core_transport(core_transport)
     pedestal_mask = (
         self.geo.rho_face_norm > self.pedestal_model_output.rho_norm_ped_top
     )
 
-    # Check turbulent and Pereverzev transport is scaled correctly.
+    # Check turbulent transport is scaled correctly.
     for field_name in [
         'chi_face_el',
         'chi_face_el_bohm',
         'chi_face_el_gyrobohm',
-        'chi_face_el_pereverzev',
     ]:
       field = getattr(modified_core_transport, field_name)
       np.testing.assert_allclose(
@@ -139,26 +147,19 @@ class PedestalModelOutputTest(absltest.TestCase):
         'chi_face_ion',
         'chi_face_ion_bohm',
         'chi_face_ion_gyrobohm',
-        'chi_face_ion_pereverzev',
     ]:
       field = getattr(modified_core_transport, field_name)
       np.testing.assert_allclose(
           field,
           jnp.where(pedestal_mask, 3.0, 1.0),
       )
-    for field_name in [
-        'd_face_el',
-        'd_face_el_pereverzev',
-    ]:
+    for field_name in ['d_face_el']:
       field = getattr(modified_core_transport, field_name)
       np.testing.assert_allclose(
           field,
           jnp.where(pedestal_mask, 4.0, 1.0),
       )
-    for field_name in [
-        'v_face_el',
-        'v_face_el_pereverzev',
-    ]:
+    for field_name in ['v_face_el']:
       field = getattr(modified_core_transport, field_name)
       np.testing.assert_allclose(
           field,
@@ -186,6 +187,14 @@ class PedestalModelOutputTest(absltest.TestCase):
         modified_core_transport.V_neo_ware_e,
         core_transport.V_neo_ware_e,
     )
+
+    # Numerical Pereverzev-Corrigan transport is not scaled or clipped.
+    for field in dataclasses.fields(pereverzev.PereverzevTransport):
+      with self.subTest(field=field.name):
+        np.testing.assert_array_equal(
+            getattr(modified_core_transport, field.name),
+            getattr(core_transport, field.name),
+        )
 
   def test_to_internal_boundary_conditions_tanh_profiles(self):
     """Tests mtanh-shaped IBC when pedestal_profile_form=MTANH."""

--- a/torax/_src/pedestal_model/tests/pedestal_model_output_test.py
+++ b/torax/_src/pedestal_model/tests/pedestal_model_output_test.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import dataclasses
 from unittest import mock
 from absl.testing import absltest
-import jax
 from jax import numpy as jnp
 import numpy as np
 from torax._src import state
@@ -24,7 +22,6 @@ from torax._src.geometry import circular_geometry
 from torax._src.geometry import geometry
 from torax._src.pedestal_model import pedestal_model_output
 from torax._src.pedestal_model import runtime_params as pedestal_runtime_params_lib
-from torax._src.transport_model import pereverzev
 
 # pylint: disable=invalid-name
 
@@ -49,14 +46,6 @@ class PedestalModelOutputTest(absltest.TestCase):
             v_e_multiplier=jnp.array(5.0),
         ),
     )
-    self.pedestal_runtime_params = mock.create_autospec(
-        pedestal_runtime_params_lib.RuntimeParams, instance=True
-    )
-    self.pedestal_runtime_params.chi_max = jnp.array(1.0)
-    self.pedestal_runtime_params.D_e_max = jnp.array(1.0)
-    self.pedestal_runtime_params.V_e_max = jnp.array(1.0)
-    self.pedestal_runtime_params.V_e_min = jnp.array(-1.0)
-    self.pedestal_runtime_params.pedestal_top_smoothing_width = jnp.array(0.0)
 
   def test_to_internal_boundary_conditions(self):
     ibc = self.pedestal_model_output.to_internal_boundary_conditions(self.geo)
@@ -87,15 +76,6 @@ class PedestalModelOutputTest(absltest.TestCase):
 
   def test_modify_core_transport_applies_multipliers(self):
     n_face = self.geo.rho_face_norm.shape[0]
-    rho_face = self.geo.rho_face_norm
-    pereverzev_transport = pereverzev.PereverzevTransport(
-        chi_face_ion_pereverzev=30.0 + rho_face,
-        chi_face_el_pereverzev=31.0 + rho_face,
-        full_v_heat_face_ion_pereverzev=-40.0 - rho_face,
-        full_v_heat_face_el_pereverzev=-41.0 - rho_face,
-        d_face_el_pereverzev=15.0 + rho_face,
-        v_face_el_pereverzev=-20.0 + rho_face,
-    )
     core_transport = state.CoreTransport(
         chi_face_ion=jnp.ones(n_face),
         chi_face_el=jnp.ones(n_face),
@@ -119,15 +99,26 @@ class PedestalModelOutputTest(absltest.TestCase):
         D_neo_e=jnp.ones(n_face),
         V_neo_e=jnp.ones(n_face),
         V_neo_ware_e=jnp.ones(n_face),
-        **dataclasses.asdict(pereverzev_transport),
+        chi_face_ion_pereverzev=jnp.ones(n_face),
+        chi_face_el_pereverzev=jnp.ones(n_face),
+        full_v_heat_face_ion_pereverzev=jnp.ones(n_face),
+        full_v_heat_face_el_pereverzev=jnp.ones(n_face),
+        d_face_el_pereverzev=jnp.ones(n_face),
+        v_face_el_pereverzev=jnp.ones(n_face),
     )
 
-    modify_core_transport = jax.jit(
-        lambda transport: self.pedestal_model_output.modify_core_transport(
-            transport, self.geo, self.pedestal_runtime_params
-        )
+    pedestal_runtime_params = mock.create_autospec(
+        pedestal_runtime_params_lib.RuntimeParams, instance=True
     )
-    modified_core_transport = modify_core_transport(core_transport)
+    pedestal_runtime_params.chi_max = jnp.array(1.0)
+    pedestal_runtime_params.D_e_max = jnp.array(1.0)
+    pedestal_runtime_params.V_e_max = jnp.array(1.0)
+    pedestal_runtime_params.V_e_min = jnp.array(-1.0)
+    pedestal_runtime_params.pedestal_top_smoothing_width = jnp.array(0.0)
+
+    modified_core_transport = self.pedestal_model_output.modify_core_transport(
+        core_transport, self.geo, pedestal_runtime_params
+    )
     pedestal_mask = (
         self.geo.rho_face_norm > self.pedestal_model_output.rho_norm_ped_top
     )
@@ -188,13 +179,19 @@ class PedestalModelOutputTest(absltest.TestCase):
         core_transport.V_neo_ware_e,
     )
 
-    # Numerical Pereverzev-Corrigan transport is not scaled or clipped.
-    for field in dataclasses.fields(pereverzev.PereverzevTransport):
-      with self.subTest(field=field.name):
-        np.testing.assert_array_equal(
-            getattr(modified_core_transport, field.name),
-            getattr(core_transport, field.name),
-        )
+    # Check numerical Pereverzev-Corrigan transport is not affected.
+    for field_name in [
+        'chi_face_ion_pereverzev',
+        'chi_face_el_pereverzev',
+        'full_v_heat_face_ion_pereverzev',
+        'full_v_heat_face_el_pereverzev',
+        'd_face_el_pereverzev',
+        'v_face_el_pereverzev',
+    ]:
+      np.testing.assert_allclose(
+          getattr(modified_core_transport, field_name),
+          getattr(core_transport, field_name),
+      )
 
   def test_to_internal_boundary_conditions_tanh_profiles(self):
     """Tests mtanh-shaped IBC when pedestal_profile_form=MTANH."""

--- a/torax/_src/transport_model/tests/transport_model_test.py
+++ b/torax/_src/transport_model/tests/transport_model_test.py
@@ -362,8 +362,8 @@ class TransportMaskingTest(parameterized.TestCase):
 
 class TransportModelTest(absltest.TestCase):
 
-  def test_adaptive_transport_preserves_pereverzev_transport_in_h_mode(self):
-    """H-mode adaptive suppression leaves numerical PC transport unchanged."""
+  def test_adaptive_transport_preserves_pereverzev_transport(self):
+    """Adaptive transport leaves numerical PC transport unchanged."""
     config = default_configs.get_default_config_dict()
     config['solver'] = {
         'chi_pereverzev': 30.0,
@@ -373,12 +373,6 @@ class TransportModelTest(absltest.TestCase):
         'model_name': 'set_T_ped_n_ped',
         'set_pedestal': True,
         'mode': 'ADAPTIVE_TRANSPORT',
-    }
-    config['sources'] = {
-        'generic_heat': {
-            'P_total': 1e9,
-            'is_explicit': True,
-        }
     }
     torax_config = model_config.ToraxConfig.from_dict(config)
     models = torax_config.build_models()
@@ -392,36 +386,22 @@ class TransportModelTest(absltest.TestCase):
         models.source_models,
         models.neoclassical_models,
     )
-    source_profiles = source_profile_builders.build_source_profiles(
-        runtime_params=runtime_params,
-        geo=geo,
-        core_profiles=core_profiles,
-        source_models=models.source_models,
-        neoclassical_models=models.neoclassical_models,
-        explicit=True,
+    pedestal_output = pedestal_model_output_lib.PedestalModelOutput(
+        rho_norm_ped_top=jnp.array(0.8),
+        T_i_ped=jnp.array(1.0),
+        T_e_ped=jnp.array(1.0),
+        n_e_ped=jnp.array(1e19),
+        transport_multipliers=pedestal_model_output_lib.TransportMultipliers(
+            chi_e_multiplier=jnp.array(0.1),
+            chi_i_multiplier=jnp.array(0.2),
+            D_e_multiplier=jnp.array(0.3),
+            v_e_multiplier=jnp.array(0.4),
+        ),
     )
     transition_state = dataclasses.replace(
         pedestal_transition_state_lib.PedestalTransitionState.empty_L_mode(),
-        confinement_mode=jnp.asarray(
-            pedestal_transition_state_lib.ConfinementMode.H_MODE
-        ),
-    )
-    pedestal_output = models.pedestal_model(
-        runtime_params,
-        geo,
-        core_profiles,
-        source_profiles,
-        transition_state,
-    )
-    transition_state = dataclasses.replace(
-        transition_state,
         pedestal_model_output=pedestal_output,
     )
-    for multiplier in dataclasses.astuple(
-        pedestal_output.transport_multipliers
-    ):
-      # check pedestal transport multiplier is on
-      self.assertLess(multiplier, 1.0)
 
     coeffs = transport_coefficients_builder.calculate_all_transport_coeffs(
         models.transport_model,

--- a/torax/_src/transport_model/tests/transport_model_test.py
+++ b/torax/_src/transport_model/tests/transport_model_test.py
@@ -362,8 +362,8 @@ class TransportMaskingTest(parameterized.TestCase):
 
 class TransportModelTest(absltest.TestCase):
 
-  def test_adaptive_transport_preserves_pereverzev_transport(self):
-    """Adaptive suppression leaves numerical PC transport unchanged."""
+  def test_adaptive_transport_preserves_pereverzev_transport_in_h_mode(self):
+    """H-mode adaptive suppression leaves numerical PC transport unchanged."""
     config = default_configs.get_default_config_dict()
     config['solver'] = {
         'chi_pereverzev': 30.0,
@@ -373,6 +373,12 @@ class TransportModelTest(absltest.TestCase):
         'model_name': 'set_T_ped_n_ped',
         'set_pedestal': True,
         'mode': 'ADAPTIVE_TRANSPORT',
+    }
+    config['sources'] = {
+        'generic_heat': {
+            'P_total': 1e9,
+            'is_explicit': True,
+        }
     }
     torax_config = model_config.ToraxConfig.from_dict(config)
     models = torax_config.build_models()
@@ -386,22 +392,36 @@ class TransportModelTest(absltest.TestCase):
         models.source_models,
         models.neoclassical_models,
     )
-    pedestal_output = pedestal_model_output_lib.PedestalModelOutput(
-        rho_norm_ped_top=0.5,
-        T_i_ped=1.0,
-        T_e_ped=1.0,
-        n_e_ped=1e19,
-        transport_multipliers=pedestal_model_output_lib.TransportMultipliers(
-            chi_e_multiplier=0.1,
-            chi_i_multiplier=0.1,
-            D_e_multiplier=0.1,
-            v_e_multiplier=0.1,
-        ),
+    source_profiles = source_profile_builders.build_source_profiles(
+        runtime_params=runtime_params,
+        geo=geo,
+        core_profiles=core_profiles,
+        source_models=models.source_models,
+        neoclassical_models=models.neoclassical_models,
+        explicit=True,
     )
     transition_state = dataclasses.replace(
         pedestal_transition_state_lib.PedestalTransitionState.empty_L_mode(),
+        confinement_mode=jnp.asarray(
+            pedestal_transition_state_lib.ConfinementMode.H_MODE
+        ),
+    )
+    pedestal_output = models.pedestal_model(
+        runtime_params,
+        geo,
+        core_profiles,
+        source_profiles,
+        transition_state,
+    )
+    transition_state = dataclasses.replace(
+        transition_state,
         pedestal_model_output=pedestal_output,
     )
+    for multiplier in dataclasses.astuple(
+        pedestal_output.transport_multipliers
+    ):
+      # check pedestal transport multiplier is on
+      self.assertLess(multiplier, 1.0)
 
     coeffs = transport_coefficients_builder.calculate_all_transport_coeffs(
         models.transport_model,

--- a/torax/_src/transport_model/tests/transport_model_test.py
+++ b/torax/_src/transport_model/tests/transport_model_test.py
@@ -35,9 +35,11 @@ from torax._src.torax_pydantic import model_config
 from torax._src.torax_pydantic import torax_pydantic
 from torax._src.transport_model import component
 from torax._src.transport_model import enums
+from torax._src.transport_model import pereverzev
 from torax._src.transport_model import pydantic_model_base as transport_pydantic_model_base
 from torax._src.transport_model import register_model
 from torax._src.transport_model import runtime_params as transport_runtime_params_lib
+from torax._src.transport_model import transport_coefficients_builder
 from torax._src.transport_model import transport_model
 
 
@@ -359,6 +361,74 @@ class TransportMaskingTest(parameterized.TestCase):
 
 
 class TransportModelTest(absltest.TestCase):
+
+  def test_adaptive_transport_preserves_pereverzev_transport(self):
+    """Adaptive suppression leaves numerical PC transport unchanged."""
+    config = default_configs.get_default_config_dict()
+    config['solver'] = {
+        'chi_pereverzev': 30.0,
+        'D_pereverzev': 15.0,
+    }
+    config['pedestal'] = {
+        'model_name': 'set_T_ped_n_ped',
+        'set_pedestal': True,
+        'mode': 'ADAPTIVE_TRANSPORT',
+    }
+    torax_config = model_config.ToraxConfig.from_dict(config)
+    models = torax_config.build_models()
+    runtime_params = build_runtime_params.RuntimeParamsProvider.from_config(
+        torax_config
+    )(t=0.0)
+    geo = torax_config.geometry.build_provider(t=0.0)
+    core_profiles = initialization.initial_core_profiles(
+        runtime_params,
+        geo,
+        models.source_models,
+        models.neoclassical_models,
+    )
+    pedestal_output = pedestal_model_output_lib.PedestalModelOutput(
+        rho_norm_ped_top=0.5,
+        T_i_ped=1.0,
+        T_e_ped=1.0,
+        n_e_ped=1e19,
+        transport_multipliers=pedestal_model_output_lib.TransportMultipliers(
+            chi_e_multiplier=0.1,
+            chi_i_multiplier=0.1,
+            D_e_multiplier=0.1,
+            v_e_multiplier=0.1,
+        ),
+    )
+    transition_state = dataclasses.replace(
+        pedestal_transition_state_lib.PedestalTransitionState.empty_L_mode(),
+        pedestal_model_output=pedestal_output,
+    )
+
+    coeffs = transport_coefficients_builder.calculate_all_transport_coeffs(
+        models.transport_model,
+        models.neoclassical_models,
+        runtime_params,
+        geo,
+        core_profiles,
+        transition_state,
+        use_pereverzev=True,
+    )
+
+    two_point_mask = pedestal_output.get_two_point_face_mask(
+        geo, set_pedestal=runtime_params.pedestal.set_pedestal
+    )
+    raw_pereverzev = pereverzev.calculate_pereverzev_transport(
+        runtime_params,
+        geo,
+        core_profiles,
+        two_point_mask,
+    )
+    for field in dataclasses.fields(pereverzev.PereverzevTransport):
+      with self.subTest(field=field.name):
+        np.testing.assert_allclose(
+            getattr(coeffs, field.name),
+            getattr(raw_pereverzev, field.name),
+            rtol=1e-12,
+        )
 
   def test_combining(self):
     config = default_configs.get_default_config_dict()

--- a/torax/_src/transport_model/transport_coefficients_builder.py
+++ b/torax/_src/transport_model/transport_coefficients_builder.py
@@ -148,8 +148,9 @@ def calculate_all_transport_coeffs(
       **dataclasses.asdict(pereverzev_transport_coeffs),
   )
 
-  # Modify the turbulent + Pereverzev transport coefficients if the pedestal
-  # model is in ADAPTIVE_TRANSPORT mode.
+  # Modify the turbulent transport coefficients if the pedestal model is in
+  # ADAPTIVE_TRANSPORT mode. Pereverzev-Corrigan terms are numerical
+  # stabilization and are kept unchanged so their paired fluxes cancel.
   if (
       runtime_params.pedestal.mode
       == pedestal_runtime_params_lib.Mode.ADAPTIVE_TRANSPORT


### PR DESCRIPTION
## Summary

I noticed when running simulations with [plasmax](https://github.com/TheodoreWolf/plasmax) many numerical errors when I turned `adaptive_transport` on. 
After some digging with agents, I found out that Pereverzev-Corrigan transport coefficients were scaled in the pedestal.

## Fix

- keep all Pereverzev-Corrigan coefficients unchanged under adaptive pedestal transport suppression so paired diffusion and counter-convection continue to cancel.
- add a test for this and fix the previous test.

## Numerical reproduction

I ran the existing ITER-hybrid adaptive L-H transition fixture (`torax/tests/test_data/test_iterhybrid_lh_transition.py`) to 60 s in three cases:

- `main`: existing behavior at `3ef7bdec`
- `main, P-C disabled`: the same revision with `solver.use_pereverzev=False`, as a diagnostic control
- `this PR`: the same configuration with the fix

| case | accepted steps | median dt [s] | retried steps | max P-C balance defect |
|---|---:|---:|---:|---:|
| main | 945 | 0.015625 | 883 | 0.973 |
| main, P-C disabled | 96 | 0.5 | 36 | NA |
| this PR | 87 | 1.0 | 33 | ~2e-16 |

All three runs reached 60 s with `NO_ERROR`.
