### PR TITLE
Pre-interpolate time-dependent geometries for fixed time-step simulations

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -2662,6 +2662,12 @@ time_step_calculator
     ``numerics`` config dict, then in practice some steps may have lower ``dt``
     if the solver needed to backtrack.
 
+    When all time steps are known in advance (constant ``fixed_dt``,
+    ``adaptive_dt==False``, no sawtooth model and no restart), a time-dependent
+    geometry is interpolated once onto every time step before the simulation
+    starts, instead of on every step. This reduces both compile time and run
+    time, at the cost of storing one geometry per time step in memory.
+
 * ``'chi'``
     adaptive dt method, where ``dt`` is a multiple of a base dt inspired by the
     explicit stability limit for parabolic PDEs:

--- a/torax/_src/geometry/geometry_provider.py
+++ b/torax/_src/geometry/geometry_provider.py
@@ -17,6 +17,7 @@
 NOTE: Time dependent providers currently live in `geometry.py` and match the
 protocol defined here.
 """
+
 from collections.abc import Mapping
 import dataclasses
 import functools
@@ -26,6 +27,7 @@ import chex
 import jax
 from jax import numpy as jnp
 import numpy as np
+from torax._src import array_typing
 from torax._src import interpolated_param
 from torax._src import jax_utils
 from torax._src.geometry import geometry
@@ -35,6 +37,17 @@ import typing_extensions
 # Using invalid-name because we are using the same naming convention as the
 # external physics implementations
 # pylint: disable=invalid-name
+
+# Maximum distance [s] between a requested time and the nearest precomputed
+# time for the request to be considered on the precomputed grid. Precomputed
+# times are generated with the same floating point accumulation as the
+# simulation loop, so on-grid requests should match to rounding precision.
+_PRECOMPUTED_TIME_TOLERANCE: float = 1e-9
+
+# Geometry fields that are not stacked along the time axis.
+_NON_STACKED_GEOMETRY_FIELDS: frozenset[str] = frozenset(
+    {'geometry_type', 'torax_mesh'}
+)
 
 
 class GeometryProvider(Protocol):
@@ -106,6 +119,87 @@ class ConstantGeometryProvider(GeometryProvider):
   @property
   def torax_mesh(self) -> torax_pydantic.Grid1D:
     return self.geo.torax_mesh
+
+
+@jax.tree_util.register_dataclass
+@dataclasses.dataclass(frozen=True)
+class PrecomputedGeometryProvider(GeometryProvider):
+  """Returns geometries precomputed at a known set of times.
+
+  When all the times a simulation will visit are known in advance (e.g. when
+  using the fixed time step calculator), the time interpolation performed by
+  `TimeDependentGeometryProvider` on every step can be done once up front. This
+  provider stores the resulting geometries stacked along a leading time axis
+  and serves them by nearest-time lookup, which is much cheaper to compile and
+  run than interpolating every geometry attribute on every call.
+
+  Requests must lie on the precomputed time grid. Off-grid requests return the
+  geometry at the nearest precomputed time, and raise an error if
+  `TORAX_ERRORS_ENABLED` is set.
+
+  Attributes:
+    times: Sorted times [s] at which geometries were precomputed, shape (N,).
+    geometries: Geometry with all array attributes stacked along a leading time
+      axis of size N, in the same order as `times`.
+  """
+
+  times: array_typing.FloatVector
+  geometries: geometry.Geometry
+
+  @classmethod
+  def from_provider(
+      cls,
+      provider: GeometryProvider,
+      times: array_typing.Array,
+  ) -> typing_extensions.Self:
+    """Precomputes geometries from `provider` at each time in `times`.
+
+    Args:
+      provider: The geometry provider to evaluate.
+      times: 1D array of times [s] at which to evaluate the provider.
+
+    Returns:
+      A `PrecomputedGeometryProvider` holding the stacked geometries.
+    """
+    times = jnp.asarray(times, dtype=jax_utils.get_dtype())
+    jax_utils.assert_rank(times, 1)
+    stacked = jax.jit(jax.vmap(lambda p, t: p(t), in_axes=(None, 0)))(
+        provider, times
+    )
+    # Non-array attributes are traced and broadcast by jit/vmap; restore their
+    # Python values.
+    stacked = dataclasses.replace(
+        stacked,
+        geometry_type=geometry.GeometryType(int(stacked.geometry_type[0])),
+        torax_mesh=provider.torax_mesh,
+    )
+    return cls(times=times, geometries=stacked)
+
+  def __call__(self, t: chex.Numeric) -> geometry.Geometry:
+    """Returns the precomputed geometry at the time nearest to `t`."""
+    chex.assert_type(t, jnp.floating)
+    index = jnp.argmin(jnp.abs(self.times - t))
+    index = jax_utils.error_if(
+        index,
+        jnp.abs(self.times[index] - t) > _PRECOMPUTED_TIME_TOLERANCE,
+        'Requested geometry at a time not on the precomputed time grid.',
+    )
+    kwargs = {}
+    for field in dataclasses.fields(self.geometries):
+      value = getattr(self.geometries, field.name)
+      if (
+          field.name in _NON_STACKED_GEOMETRY_FIELDS
+          or field.metadata.get('static', False)
+          or value is None
+      ):
+        kwargs[field.name] = value
+      else:
+        kwargs[field.name] = value[index]
+    return self.geometries.__class__(**kwargs)
+
+  @property
+  def torax_mesh(self) -> torax_pydantic.Grid1D:
+    return self.geometries.torax_mesh
 
 
 @jax.tree_util.register_dataclass
@@ -200,16 +294,18 @@ class TimeDependentGeometryProvider:
         continue
 
       # Remaining attributes are set up for interpolation.
-      kwargs[attr.name] = interpolated_param.InterpolatedVarSingleAxis(  # pyrefly: ignore[unsupported-operation]
-          (
-              times,
-              np.stack(
-                  [getattr(g, attr.name) for g in geos],
-                  axis=0,
-                  dtype=jax_utils.get_np_dtype(),
+      kwargs[attr.name] = (
+          interpolated_param.InterpolatedVarSingleAxis(  # pyrefly: ignore[unsupported-operation]
+              (
+                  times,
+                  np.stack(
+                      [getattr(g, attr.name) for g in geos],
+                      axis=0,
+                      dtype=jax_utils.get_np_dtype(),
+                  ),
               ),
-          ),
-          is_bool_param=isinstance(initial_val, bool),
+              is_bool_param=isinstance(initial_val, bool),
+          )
       )
     return cls(**kwargs)  # pyrefly: ignore[missing-argument]
 
@@ -236,13 +332,17 @@ class TimeDependentGeometryProvider:
               _Phi_b_grad(self.Phi_face, t), dtype=jax_utils.get_dtype()
           )
         else:
-          kwargs[attr.name] = jnp.zeros((), dtype=jax_utils.get_dtype())  # pyrefly: ignore[bad-assignment]
+          kwargs[attr.name] = jnp.zeros(
+              (), dtype=jax_utils.get_dtype()
+          )  # pyrefly: ignore[bad-assignment]
         continue
       provider_attr = getattr(self, attr.name)
       if isinstance(
           provider_attr, interpolated_param.InterpolatedVarSingleAxis
       ):
-        kwargs[attr.name] = provider_attr.get_value(t)  # pyrefly: ignore[unsupported-operation]
+        kwargs[attr.name] = provider_attr.get_value(
+            t
+        )  # pyrefly: ignore[unsupported-operation]
       else:
         # For None attributes.
         kwargs[attr.name] = provider_attr

--- a/torax/_src/geometry/tests/geometry_provider_test.py
+++ b/torax/_src/geometry/tests/geometry_provider_test.py
@@ -15,13 +15,50 @@
 import dataclasses
 
 from absl.testing import absltest
+from absl.testing import parameterized
+import chex
+import jax
+import jax.numpy as jnp
 import numpy as np
+from torax._src import jax_utils
 from torax._src.geometry import circular_geometry
 from torax._src.geometry import geometry
 from torax._src.geometry import geometry_provider
+from torax._src.geometry import pydantic_model as geometry_pydantic_model
+from torax._src.geometry import standard_geometry
 
 
-class GeometryProviderTest(absltest.TestCase):
+def _build_time_dependent_circular_provider(
+    calcphibdot: bool = True,
+) -> geometry_provider.TimeDependentGeometryProvider:
+  geo_0 = circular_geometry.CircularConfig(
+      R_major=6.2, a_minor=2.0, B_0=5.3
+  ).build_geometry()
+  geo_1 = circular_geometry.CircularConfig(
+      R_major=7.4, a_minor=1.0, B_0=6.5
+  ).build_geometry()
+  return geometry_provider.TimeDependentGeometryProvider.create_provider(
+      {0.0: geo_0, 10.0: geo_1}, calcphibdot=calcphibdot
+  )
+
+
+def _build_time_dependent_chease_provider() -> (
+    standard_geometry.StandardGeometryProvider
+):
+  provider = geometry_pydantic_model.Geometry.from_dict({
+      'geometry_type': 'chease',
+      'Ip_from_parameters': True,
+      'n_rho': 10,
+      'geometry_configs': {
+          0.0: {'geometry_file': 'iterhybrid.mat2cols', 'R_major': 6.2},
+          10.0: {'geometry_file': 'iterhybrid.mat2cols', 'R_major': 7.0},
+      },
+  }).build_provider
+  assert isinstance(provider, standard_geometry.StandardGeometryProvider)
+  return provider
+
+
+class GeometryProviderTest(parameterized.TestCase):
 
   def test_constant_geometry_return_same_value(self):
     geo = circular_geometry.CircularConfig().build_geometry()
@@ -38,7 +75,8 @@ class GeometryProviderTest(absltest.TestCase):
         R_major=7.4, a_minor=1.0, B_0=6.5
     ).build_geometry()
     provider = geometry_provider.TimeDependentGeometryProvider.create_provider(
-        {0.0: geo_0, 10.0: geo_1}, calcphibdot=True,
+        {0.0: geo_0, 10.0: geo_1},
+        calcphibdot=True,
     )
     geo = provider(5.0)
     np.testing.assert_allclose(geo.R_major, 6.8)
@@ -49,31 +87,95 @@ class GeometryProviderTest(absltest.TestCase):
     geo_0 = circular_geometry.CircularConfig().build_geometry()
     geo_1 = dataclasses.replace(geo_0, geometry_type=geometry.GeometryType.FBT)
     with self.assertRaisesRegex(
-        ValueError, "All geometries must have the same geometry type."
+        ValueError, 'All geometries must have the same geometry type.'
     ):
       geometry_provider.TimeDependentGeometryProvider.create_provider(
-          {0.0: geo_0, 10.0: geo_1}, calcphibdot=True,
+          {0.0: geo_0, 10.0: geo_1},
+          calcphibdot=True,
       )
 
   def test_time_dependent_different_meshes(self):
     geo_0 = circular_geometry.CircularConfig(n_rho=25).build_geometry()
     geo_1 = circular_geometry.CircularConfig(n_rho=50).build_geometry()
     with self.assertRaisesRegex(
-        ValueError, "All geometries must have the same mesh."
+        ValueError, 'All geometries must have the same mesh.'
     ):
       geometry_provider.TimeDependentGeometryProvider.create_provider(
-          {0.0: geo_0, 10.0: geo_1}, calcphibdot=True,
+          {0.0: geo_0, 10.0: geo_1},
+          calcphibdot=True,
       )
 
   def test_none_z_magnetic_axis_stays_none_time_dependent(self):
     geo = circular_geometry.CircularConfig().build_geometry()
     geo = dataclasses.replace(geo, _z_magnetic_axis=None)
     provider = geometry_provider.TimeDependentGeometryProvider.create_provider(
-        {0.0: geo, 10.0: geo}, calcphibdot=True,
+        {0.0: geo, 10.0: geo},
+        calcphibdot=True,
     )
     self.assertIsNone(provider(0.0)._z_magnetic_axis)
     self.assertIsNone(provider(10.0)._z_magnetic_axis)
 
+  @parameterized.named_parameters(
+      ('circular', _build_time_dependent_circular_provider),
+      ('chease', _build_time_dependent_chease_provider),
+  )
+  def test_precomputed_matches_interpolating_provider(self, build_provider):
+    provider = build_provider()
+    times = np.array([0.0, 2.5, 5.0, 7.5, 10.0], dtype=jax_utils.get_np_dtype())
+    precomputed = geometry_provider.PrecomputedGeometryProvider.from_provider(
+        provider, times
+    )
+    self.assertEqual(precomputed.torax_mesh, provider.torax_mesh)
+    for t in times:
+      with self.subTest(t=t):
+        expected = provider(t)
+        actual = precomputed(t)
+        self.assertIs(type(actual), type(expected))
+        self.assertEqual(actual.geometry_type, expected.geometry_type)
+        chex.assert_trees_all_close(actual, expected)
 
-if __name__ == "__main__":
+  def test_precomputed_matches_interpolating_provider_under_jit(self):
+    provider = _build_time_dependent_circular_provider()
+    times = np.array([0.0, 5.0, 10.0], dtype=jax_utils.get_np_dtype())
+    precomputed = geometry_provider.PrecomputedGeometryProvider.from_provider(
+        provider, times
+    )
+    jitted = jax.jit(lambda p, t: p(t))
+    chex.assert_trees_all_close(
+        jitted(precomputed, jnp.asarray(5.0)), provider(5.0)
+    )
+
+  def test_precomputed_preserves_none_attributes_and_zero_phibdot(self):
+    provider = _build_time_dependent_circular_provider(calcphibdot=False)
+    geo = dataclasses.replace(provider(0.0), _z_magnetic_axis=None)
+    provider = geometry_provider.TimeDependentGeometryProvider.create_provider(
+        {0.0: geo, 10.0: geo}, calcphibdot=False
+    )
+    precomputed = geometry_provider.PrecomputedGeometryProvider.from_provider(
+        provider, np.array([0.0, 10.0])
+    )
+    geo_precomputed = precomputed(0.0)
+    self.assertIsNone(geo_precomputed._z_magnetic_axis)
+    np.testing.assert_array_equal(geo_precomputed.Phi_b_dot, 0.0)
+
+  def test_precomputed_returns_nearest_time_off_grid(self):
+    provider = _build_time_dependent_circular_provider()
+    precomputed = geometry_provider.PrecomputedGeometryProvider.from_provider(
+        provider, np.array([0.0, 10.0])
+    )
+    chex.assert_trees_all_close(precomputed(4.0), provider(0.0))
+    chex.assert_trees_all_close(precomputed(6.0), provider(10.0))
+
+  def test_precomputed_raises_off_grid_when_errors_enabled(self):
+    provider = _build_time_dependent_circular_provider()
+    precomputed = geometry_provider.PrecomputedGeometryProvider.from_provider(
+        provider, np.array([0.0, 10.0])
+    )
+    with jax_utils.enable_errors(True):
+      precomputed(0.0)  # On grid, no error.
+      with self.assertRaisesRegex(RuntimeError, 'not on the precomputed'):
+        precomputed(4.0)
+
+
+if __name__ == '__main__':
   absltest.main()

--- a/torax/_src/orchestration/run_simulation.py
+++ b/torax/_src/orchestration/run_simulation.py
@@ -84,11 +84,11 @@ def _maybe_precompute_geometry_provider(
       fixed_dt=float(fixed_dt.value[0]),
       exact_t_final=numerics.exact_t_final,
       tolerance=torax_config.time_step_calculator.tolerance,
+      max_num_times=_MAX_PRECOMPUTED_GEOMETRIES,
   )
-  if len(times) > _MAX_PRECOMPUTED_GEOMETRIES:
+  if times is None:
     logging.info(
-        'Not precomputing geometries: %d geometries exceeds the maximum of %d.',
-        len(times),
+        'Not precomputing geometries: the grid exceeds the maximum of %d.',
         _MAX_PRECOMPUTED_GEOMETRIES,
     )
     return geometry_provider

--- a/torax/_src/orchestration/run_simulation.py
+++ b/torax/_src/orchestration/run_simulation.py
@@ -24,7 +24,9 @@ new_sim_outputs = torax.run_simulation(torax_config)
 ```
 """
 
+from absl import logging
 from torax._src.config import build_runtime_params
+from torax._src.geometry import geometry_provider as geometry_provider_lib
 from torax._src.orchestration import initial_state as initial_state_lib
 from torax._src.orchestration import jit_run_loop
 from torax._src.orchestration import run_loop
@@ -32,15 +34,78 @@ from torax._src.orchestration import sim_state
 from torax._src.orchestration import step_function
 from torax._src.output_tools import output
 from torax._src.output_tools import post_processing
+from torax._src.time_step_calculator import fixed_time_step_calculator
+from torax._src.time_step_calculator import pydantic_model as time_step_calculator_pydantic_model
 from torax._src.torax_pydantic import model_config
 import xarray as xr
+
+# Upper bound on the number of geometries to precompute, to bound memory usage
+# (each geometry is ~13 kB at n_rho=25, scaling linearly with n_rho).
+_MAX_PRECOMPUTED_GEOMETRIES: int = 10_000
+
+
+def _maybe_precompute_geometry_provider(
+    torax_config: model_config.ToraxConfig,
+    geometry_provider: geometry_provider_lib.GeometryProvider,
+) -> geometry_provider_lib.GeometryProvider:
+  """Pre-interpolates a time-dependent geometry when all step times are known.
+
+  This is only possible when the fixed time step calculator is used with a
+  constant `fixed_dt` and nothing can alter the sequence of time steps
+  (adaptive dt, sawtooth crashes, or a restart from a different start time).
+
+  Args:
+    torax_config: The TORAX config.
+    geometry_provider: The geometry provider built from the config.
+
+  Returns:
+    A `PrecomputedGeometryProvider` if precomputation is possible, otherwise
+    `geometry_provider` unchanged.
+  """
+  numerics = torax_config.numerics
+  fixed_dt = numerics.fixed_dt
+  if (
+      isinstance(
+          geometry_provider, geometry_provider_lib.ConstantGeometryProvider
+      )
+      or torax_config.time_step_calculator.calculator_type
+      != time_step_calculator_pydantic_model.TimeStepCalculatorType.FIXED
+      or numerics.adaptive_dt
+      or torax_config.mhd.sawtooth is not None
+      or (torax_config.restart is not None and torax_config.restart.do_restart)
+      or len(fixed_dt.value) != 1
+      or fixed_dt.value[0] <= 0.0
+  ):
+    return geometry_provider
+
+  times = fixed_time_step_calculator.get_time_grid(
+      t_initial=numerics.t_initial,
+      t_final=numerics.t_final,
+      fixed_dt=float(fixed_dt.value[0]),
+      exact_t_final=numerics.exact_t_final,
+      tolerance=torax_config.time_step_calculator.tolerance,
+  )
+  if len(times) > _MAX_PRECOMPUTED_GEOMETRIES:
+    logging.info(
+        'Not precomputing geometries: %d geometries exceeds the maximum of %d.',
+        len(times),
+        _MAX_PRECOMPUTED_GEOMETRIES,
+    )
+    return geometry_provider
+
+  logging.info('Precomputing geometries at %d fixed time steps.', len(times))
+  return geometry_provider_lib.PrecomputedGeometryProvider.from_provider(
+      geometry_provider, times
+  )
 
 
 def make_step_fn(
     torax_config: model_config.ToraxConfig,
 ) -> step_function.SimulationStepFn:
   """Prepare a TORAX step function from a config."""
-  geometry_provider = torax_config.geometry.build_provider
+  geometry_provider = _maybe_precompute_geometry_provider(
+      torax_config, torax_config.geometry.build_provider
+  )
   models = torax_config.build_models()
 
   solver = torax_config.solver.build_solver(

--- a/torax/_src/orchestration/tests/run_simulation_test.py
+++ b/torax/_src/orchestration/tests/run_simulation_test.py
@@ -200,9 +200,9 @@ class RunSimulationTest(sim_test_case.SimTestCase):
 
   def test_geometry_is_not_precomputed_above_geometry_cap(self):
     config_dict = self._get_fixed_dt_time_dependent_geometry_config()
-    config_dict['numerics']['t_final'] = 1_000.0
     torax_config = model_config.ToraxConfig.from_dict(config_dict)
-    step_fn = run_simulation.make_step_fn(torax_config)
+    with mock.patch.object(run_simulation, '_MAX_PRECOMPUTED_GEOMETRIES', 3):
+      step_fn = run_simulation.make_step_fn(torax_config)
     self.assertIsInstance(
         step_fn.geometry_provider,
         geometry_provider_lib.TimeDependentGeometryProvider,

--- a/torax/_src/orchestration/tests/run_simulation_test.py
+++ b/torax/_src/orchestration/tests/run_simulation_test.py
@@ -13,14 +13,21 @@
 # limitations under the License.
 import logging
 import os
+from typing import Any
+from unittest import mock
 
 from absl.testing import absltest
 from absl.testing import parameterized
+import chex
 import numpy as np
 from torax._src import state
+from torax._src.geometry import geometry as geometry_lib
+from torax._src.geometry import geometry_provider as geometry_provider_lib
 from torax._src.orchestration import run_simulation
 from torax._src.output_tools import output
+from torax._src.test_utils import default_configs
 from torax._src.test_utils import sim_test_case
+from torax._src.torax_pydantic import model_config
 import xarray as xr
 
 _ALL_PROFILES = ('T_i', 'T_e', 'psi', 'q_face', 's_face', 'n_e')
@@ -59,7 +66,8 @@ class RunSimulationTest(sim_test_case.SimTestCase):
 
     # Stitch the restart state file to the beginning of the reference dataset.
     datatree_new = output.stitch_state_files(
-        torax_config.restart, data_tree_restart  # pyrefly: ignore[bad-argument-type]
+        torax_config.restart,
+        data_tree_restart,  # pyrefly: ignore[bad-argument-type]
     )
 
     # Check that time coordinates agree.
@@ -121,12 +129,120 @@ class RunSimulationTest(sim_test_case.SimTestCase):
     torax_config = self._get_torax_config('test_implicit.py')
 
     # Use max_steps=1 which is far too few to reach t_final=1.
-    _, state_history = run_simulation.run_simulation(
-        torax_config, max_steps=1
-    )
+    _, state_history = run_simulation.run_simulation(torax_config, max_steps=1)
 
     self.assertEqual(
         state_history.sim_error, state.SimError.DID_NOT_REACH_T_FINAL
+    )
+
+  def _get_fixed_dt_time_dependent_geometry_config(self) -> dict[str, Any]:
+    config_dict = default_configs.get_default_config_dict()
+    config_dict['geometry'] = {
+        'geometry_type': 'circular',
+        'n_rho': 4,
+        'geometry_configs': {
+            0.0: {'R_major': 6.2},
+            1.0: {'R_major': 6.5},
+        },
+    }
+    config_dict['numerics'] = {
+        'fixed_dt': 0.1,
+        't_final': 1.0,
+        'adaptive_dt': False,
+    }
+    config_dict['time_step_calculator'] = {'calculator_type': 'fixed'}
+    return config_dict
+
+  def test_geometry_is_precomputed_for_fixed_time_steps(self):
+    config_dict = self._get_fixed_dt_time_dependent_geometry_config()
+    torax_config = model_config.ToraxConfig.from_dict(config_dict)
+    step_fn = run_simulation.make_step_fn(torax_config)
+    self.assertIsInstance(
+        step_fn.geometry_provider,
+        geometry_provider_lib.PrecomputedGeometryProvider,
+    )
+    # t_initial, 10 steps of 0.1 (t_final is reached exactly).
+    self.assertLen(step_fn.geometry_provider.times, 11)
+
+  @parameterized.named_parameters(
+      ('adaptive_dt', 'numerics', 'adaptive_dt', True),
+      ('chi_calculator', 'time_step_calculator', 'calculator_type', 'chi'),
+      ('time_varying_fixed_dt', 'numerics', 'fixed_dt', {0.0: 0.1, 0.5: 0.2}),
+      (
+          'sawtooth',
+          'mhd',
+          'sawtooth',
+          {
+              'trigger_model': {'model_name': 'simple'},
+              'redistribution_model': {'model_name': 'simple'},
+          },
+      ),
+  )
+  def test_geometry_is_not_precomputed_when_unsafe(self, section, key, value):
+    config_dict = self._get_fixed_dt_time_dependent_geometry_config()
+    config_dict.setdefault(section, {})[key] = value
+    torax_config = model_config.ToraxConfig.from_dict(config_dict)
+    step_fn = run_simulation.make_step_fn(torax_config)
+    self.assertIsInstance(
+        step_fn.geometry_provider,
+        geometry_provider_lib.TimeDependentGeometryProvider,
+    )
+
+  def test_constant_geometry_is_not_precomputed(self):
+    config_dict = self._get_fixed_dt_time_dependent_geometry_config()
+    config_dict['geometry'] = {'geometry_type': 'circular', 'n_rho': 4}
+    torax_config = model_config.ToraxConfig.from_dict(config_dict)
+    step_fn = run_simulation.make_step_fn(torax_config)
+    self.assertIsInstance(
+        step_fn.geometry_provider,
+        geometry_provider_lib.ConstantGeometryProvider,
+    )
+
+  def test_geometry_is_not_precomputed_above_geometry_cap(self):
+    config_dict = self._get_fixed_dt_time_dependent_geometry_config()
+    config_dict['numerics']['t_final'] = 1_000.0
+    torax_config = model_config.ToraxConfig.from_dict(config_dict)
+    step_fn = run_simulation.make_step_fn(torax_config)
+    self.assertIsInstance(
+        step_fn.geometry_provider,
+        geometry_provider_lib.TimeDependentGeometryProvider,
+    )
+
+  def test_precomputed_geometry_matches_interpolated_geometry(self):
+    config_dict = self._get_fixed_dt_time_dependent_geometry_config()
+    torax_config = model_config.ToraxConfig.from_dict(config_dict)
+    _, precomputed_history = run_simulation.run_simulation(
+        torax_config, progress_bar=False
+    )
+    self.assertIsInstance(
+        precomputed_history.geometries[0],
+        geometry_lib.Geometry,
+    )
+    with mock.patch.object(
+        run_simulation,
+        '_maybe_precompute_geometry_provider',
+        lambda unused_config, provider: provider,
+    ):
+      _, interpolated_history = run_simulation.run_simulation(
+          torax_config, progress_bar=False
+      )
+    self.assertEqual(
+        precomputed_history.sim_error, interpolated_history.sim_error
+    )
+    np.testing.assert_array_equal(
+        precomputed_history.times, interpolated_history.times
+    )
+    chex.assert_trees_all_close(
+        precomputed_history.core_profiles,
+        interpolated_history.core_profiles,
+    )
+    chex.assert_trees_all_close(
+        precomputed_history.geometries,
+        interpolated_history.geometries,
+    )
+    chex.assert_trees_all_close(
+        precomputed_history.post_processed_outputs,
+        interpolated_history.post_processed_outputs,
     )
 
 

--- a/torax/_src/orchestration/tests/step_function_test.py
+++ b/torax/_src/orchestration/tests/step_function_test.py
@@ -22,6 +22,7 @@ import jax.numpy as jnp
 import numpy as np
 from torax._src import state
 from torax._src.config import config_loader
+from torax._src.geometry import geometry_provider as geometry_provider_lib
 from torax._src.orchestration import run_simulation
 from torax._src.orchestration import sim_state as sim_state_lib
 from torax._src.orchestration import step_function
@@ -381,7 +382,8 @@ class StepFunctionTest(parameterized.TestCase):
 
     # Run a step with overriden Ip.
     ip_update = interpolated_param_1d.TimeVaryingScalarUpdate(
-        value=params_provider.profile_conditions.Ip.value * 2.0  # pyrefly: ignore[bad-argument-type]
+        value=params_provider.profile_conditions.Ip.value
+        * 2.0  # pyrefly: ignore[bad-argument-type]
     )
     runtime_params_overrides = params_provider.update_provider(
         lambda x: (x.profile_conditions.Ip,),
@@ -436,6 +438,45 @@ class StepFunctionTest(parameterized.TestCase):
     chex.assert_trees_all_close(override_state, ref_state)
     chex.assert_trees_all_close(
         override_post_processed_outputs, ref_post_processed_outputs
+    )
+
+  def test_step_with_precomputed_geometry_matches_interpolated_geometry(self):
+    config_dict = default_configs.get_default_config_dict()
+    config_dict['geometry'] = {
+        'geometry_type': 'circular',
+        'n_rho': 4,
+        'geometry_configs': {
+            0.0: {'R_major': 6.2},
+            1.0: {'R_major': 6.5},
+        },
+    }
+    config_dict['numerics'] = {'fixed_dt': 0.1, 'adaptive_dt': False}
+    config_dict['time_step_calculator'] = {'calculator_type': 'fixed'}
+    cfg = model_config.ToraxConfig.from_dict(config_dict)
+    (
+        sim_state,
+        post_processed_outputs,
+        step_fn,
+    ) = run_simulation.prepare_simulation(cfg)
+    self.assertIsInstance(
+        step_fn.geometry_provider,
+        geometry_provider_lib.PrecomputedGeometryProvider,
+    )
+
+    precomputed_state, precomputed_post_processed_outputs = step_fn(
+        sim_state,
+        post_processed_outputs,
+    )
+    # Override with the original interpolating provider as a reference.
+    ref_state, ref_post_processed_outputs = step_fn(
+        sim_state,
+        post_processed_outputs,
+        geo_overrides=cfg.geometry.build_provider,
+    )
+
+    chex.assert_trees_all_close(precomputed_state, ref_state)
+    chex.assert_trees_all_close(
+        precomputed_post_processed_outputs, ref_post_processed_outputs
     )
 
 

--- a/torax/_src/time_step_calculator/fixed_time_step_calculator.py
+++ b/torax/_src/time_step_calculator/fixed_time_step_calculator.py
@@ -19,9 +19,50 @@ Steps through time using a constant time step.
 
 import jax
 from jax import numpy as jnp
+import numpy as np
+from torax._src import jax_utils
 from torax._src.config import runtime_params as runtime_params_lib
 from torax._src.orchestration import sim_state as sim_state_lib
 from torax._src.time_step_calculator import time_step_calculator
+
+
+def get_time_grid(
+    t_initial: float,
+    t_final: float,
+    fixed_dt: float,
+    exact_t_final: bool,
+    tolerance: float,
+) -> np.ndarray:
+  """Returns all times visited by a simulation with a constant fixed dt.
+
+  Mirrors `TimeStepCalculator.is_done` and `TimeStepCalculator.next_dt`,
+  accumulating `t + dt` in the simulation dtype so the returned times match
+  the times reached by the simulation loop to floating point precision.
+
+  Args:
+    t_initial: Simulation start time [s].
+    t_final: Simulation end time [s].
+    fixed_dt: Constant time step [s]. Must be positive.
+    exact_t_final: Whether the final step is shortened to land on `t_final`.
+    tolerance: Tolerance within `t_final` at which the simulation is done.
+
+  Returns:
+    1D array of times, starting with `t_initial`.
+  """
+  if fixed_dt <= 0.0:
+    raise ValueError(f'fixed_dt must be positive, got {fixed_dt}.')
+  dtype = jax_utils.get_np_dtype()
+  t = dtype(t_initial)
+  t_final = dtype(t_final)
+  fixed_dt = dtype(fixed_dt)
+  times = [t]
+  while t < t_final - tolerance:
+    dt = fixed_dt
+    if exact_t_final and t < t_final < t + dt:
+      dt = t_final - t
+    t = t + dt
+    times.append(t)
+  return np.asarray(times, dtype=dtype)
 
 
 class FixedTimeStepCalculator(time_step_calculator.TimeStepCalculator):

--- a/torax/_src/time_step_calculator/fixed_time_step_calculator.py
+++ b/torax/_src/time_step_calculator/fixed_time_step_calculator.py
@@ -32,7 +32,9 @@ def get_time_grid(
     fixed_dt: float,
     exact_t_final: bool,
     tolerance: float,
-) -> np.ndarray:
+    *,
+    max_num_times: int | None = None,
+) -> np.ndarray | None:
   """Returns all times visited by a simulation with a constant fixed dt.
 
   Mirrors `TimeStepCalculator.is_done` and `TimeStepCalculator.next_dt`,
@@ -45,9 +47,12 @@ def get_time_grid(
     fixed_dt: Constant time step [s]. Must be positive.
     exact_t_final: Whether the final step is shortened to land on `t_final`.
     tolerance: Tolerance within `t_final` at which the simulation is done.
+    max_num_times: Maximum number of times to return, including `t_initial`.
+      Returns None if the grid would exceed this limit.
 
   Returns:
-    1D array of times, starting with `t_initial`.
+    A 1D array of times, starting with `t_initial`, or None if the grid would
+    exceed `max_num_times`.
   """
   if fixed_dt <= 0.0:
     raise ValueError(f'fixed_dt must be positive, got {fixed_dt}.')
@@ -56,7 +61,11 @@ def get_time_grid(
   t_final = dtype(t_final)
   fixed_dt = dtype(fixed_dt)
   times = [t]
+  if max_num_times is not None and max_num_times < 1:
+    return None
   while t < t_final - tolerance:
+    if max_num_times is not None and len(times) >= max_num_times:
+      return None
     dt = fixed_dt
     if exact_t_final and t < t_final < t + dt:
       dt = t_final - t

--- a/torax/_src/time_step_calculator/tests/time_step_calculator_test.py
+++ b/torax/_src/time_step_calculator/tests/time_step_calculator_test.py
@@ -14,6 +14,7 @@
 
 from absl.testing import absltest
 from absl.testing import parameterized
+import numpy as np
 from torax._src.orchestration import run_simulation
 from torax._src.test_utils import default_configs
 from torax._src.time_step_calculator import fixed_time_step_calculator
@@ -80,6 +81,52 @@ class TimeStepCalculatorTest(parameterized.TestCase):
         sim_state=sim_state,
     )
     self.assertEqual(dt, expected_dt)
+
+  @parameterized.named_parameters(
+      ('exact_t_final', True, [0.0, 2.0, 4.0, 5.0]),
+      ('overshoot_t_final', False, [0.0, 2.0, 4.0, 6.0]),
+  )
+  def test_get_time_grid(self, exact_t_final, expected_times):
+    times = fixed_time_step_calculator.get_time_grid(
+        t_initial=0.0,
+        t_final=5.0,
+        fixed_dt=2.0,
+        exact_t_final=exact_t_final,
+        tolerance=1e-7,
+    )
+    np.testing.assert_allclose(times, expected_times)
+
+  def test_get_time_grid_matches_simulation_times(self):
+    config_dict = default_configs.get_default_config_dict()
+    config_dict['numerics'] = {
+        'fixed_dt': 0.3,
+        't_initial': 0.0,
+        't_final': 1.0,
+        'adaptive_dt': False,
+    }
+    config_dict['time_step_calculator'] = {'calculator_type': 'fixed'}
+    torax_config = model_config.ToraxConfig.from_dict(config_dict)
+    _, state_history = run_simulation.run_simulation(
+        torax_config, progress_bar=False
+    )
+    times = fixed_time_step_calculator.get_time_grid(
+        t_initial=torax_config.numerics.t_initial,
+        t_final=torax_config.numerics.t_final,
+        fixed_dt=0.3,
+        exact_t_final=torax_config.numerics.exact_t_final,
+        tolerance=torax_config.time_step_calculator.tolerance,
+    )
+    np.testing.assert_array_equal(times, state_history.times)
+
+  def test_get_time_grid_rejects_non_positive_dt(self):
+    with self.assertRaisesRegex(ValueError, 'must be positive'):
+      fixed_time_step_calculator.get_time_grid(
+          t_initial=0.0,
+          t_final=1.0,
+          fixed_dt=0.0,
+          exact_t_final=True,
+          tolerance=1e-7,
+      )
 
 
 if __name__ == '__main__':

--- a/torax/_src/time_step_calculator/tests/time_step_calculator_test.py
+++ b/torax/_src/time_step_calculator/tests/time_step_calculator_test.py
@@ -118,6 +118,17 @@ class TimeStepCalculatorTest(parameterized.TestCase):
     )
     np.testing.assert_array_equal(times, state_history.times)
 
+  def test_get_time_grid_stops_at_max_num_times(self):
+    times = fixed_time_step_calculator.get_time_grid(
+        t_initial=0.0,
+        t_final=1_000_000.0,
+        fixed_dt=0.1,
+        exact_t_final=True,
+        tolerance=1e-7,
+        max_num_times=3,
+    )
+    self.assertIsNone(times)
+
   def test_get_time_grid_rejects_non_positive_dt(self):
     with self.assertRaisesRegex(ValueError, 'must be positive'):
       fixed_time_step_calculator.get_time_grid(

--- a/torax/benchmarks/iterhybrid_predictor_corrector_fixed_small_dt_time_dependent_geometry.py
+++ b/torax/benchmarks/iterhybrid_predictor_corrector_fixed_small_dt_time_dependent_geometry.py
@@ -1,0 +1,44 @@
+# Copyright 2026 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""iterhybrid_predictor_corrector with small fixed dt and time-dependent geo.
+
+Exercises the time interpolation of geometry on every time step, which is
+pre-computed when using the fixed time step calculator.
+"""
+
+import copy
+
+from torax.benchmarks import iterhybrid_predictor_corrector_fixed_small_dt
+
+CONFIG = copy.deepcopy(iterhybrid_predictor_corrector_fixed_small_dt.CONFIG)
+CONFIG['numerics']['adaptive_dt'] = False
+CONFIG['geometry'] = {
+    'geometry_type': 'chease',
+    'Ip_from_parameters': True,
+    'geometry_configs': {
+        0.0: {
+            'geometry_file': 'iterhybrid.mat2cols',
+            'R_major': 6.2,
+            'a_minor': 2.0,
+            'B_0': 5.3,
+        },
+        5.0: {
+            'geometry_file': 'iterhybrid.mat2cols',
+            'R_major': 6.3,
+            'a_minor': 2.0,
+            'B_0': 5.3,
+        },
+    },
+}

--- a/torax/experimental/geometry.py
+++ b/torax/experimental/geometry.py
@@ -13,14 +13,17 @@
 # limitations under the License.
 
 """Experimental library functionality for TORAX."""
+
 # pylint: disable=g-importing-member
 from torax._src.geometry.geometry_provider import ConstantGeometryProvider
+from torax._src.geometry.geometry_provider import PrecomputedGeometryProvider
 from torax._src.geometry.geometry_provider import TimeDependentGeometryProvider
 from torax._src.geometry.pydantic_model import Geometry
 from torax._src.geometry.standard_geometry import StandardGeometryProvider
 
 __all__ = [
     'ConstantGeometryProvider',
+    'PrecomputedGeometryProvider',
     'TimeDependentGeometryProvider',
     'Geometry',
     'StandardGeometryProvider',


### PR DESCRIPTION
Fixes #2315.

## Summary

For fixed time-step simulations with a constant `fixed_dt`, precompute time-dependent geometries once at setup and use a cheap nearest-time lookup during the simulation.

All other configurations preserve the existing interpolating-provider behavior.

## Validation

* `pyink` check passes for changed Python files
* `git diff --check` passes
* Targeted geometry, precompute-guard, time-grid, single-step-equivalence, and full-simulation-equivalence tests passed
* Broader orchestration and JIT suites were skipped locally because WSL became unresponsive during long JAX test runs

## Notes

The precomputed provider is publicly exported from `torax.experimental.geometry` for explicit opt-in use by the coupling path in a future change.
