### PR TITLE
Validate required IMAS geometry fields

### DIFF
--- a/torax/_src/imas_tools/input/equilibrium.py
+++ b/torax/_src/imas_tools/input/equilibrium.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Input mapping functions for use of IMAS equilibrium IDSs with TORAX."""
+
 from collections.abc import Mapping
 import logging
 from typing import Any
@@ -21,7 +22,7 @@ from imas import ids_toplevel
 import numpy as np
 import scipy
 from torax._src.imas_tools.input import loader
-
+from torax._src.imas_tools.input import validation
 
 # TODO(b/379832500) - Modify for consistency when we have a fixed TORAX COCOS.
 # pylint: disable=invalid-name
@@ -59,11 +60,17 @@ def _load_equilibrium(
     equilibrium = equilibrium_object
   elif imas_uri is not None:
     equilibrium = loader.load_imas_data(
-        imas_uri, "equilibrium", geometry_directory, explicit_convert  # pyrefly: ignore[bad-argument-type]
+        imas_uri,
+        "equilibrium",
+        geometry_directory,
+        explicit_convert,  # pyrefly: ignore[bad-argument-type]
     )
   elif imas_filepath is not None:
     equilibrium = loader.load_imas_data(
-        imas_filepath, "equilibrium", geometry_directory, explicit_convert  # pyrefly: ignore[bad-argument-type]
+        imas_filepath,
+        "equilibrium",
+        geometry_directory,
+        explicit_convert,  # pyrefly: ignore[bad-argument-type]
     )
   else:
     raise ValueError(
@@ -98,6 +105,7 @@ def _geometry_from_single_slice(
   Returns:
     A dict of intermediate geometry values for building a StandardGeometry.
   """
+  validation.validate_equilibrium_geometry_from_IMAS(equilibrium, slice_index)
   IMAS_data = equilibrium.time_slice[slice_index]
   # IMAS python API returns custom primitive types (e.g. IDSFloat0D,
   # IDSNumericArray) instead of standard python floats or numpy arrays. We must

--- a/torax/_src/imas_tools/input/tests/equilibrium_test.py
+++ b/torax/_src/imas_tools/input/tests/equilibrium_test.py
@@ -93,9 +93,7 @@ class EquilibriumTest(parameterized.TestCase):
     with mock.patch('imas.DBEntry') as mocked_class:
       mocked_class.return_value = mock_value
       imas_uri = f'imas:hdf5?path={full_path}'
-      config = imas_config.IMASConfig(
-          imas_uri=imas_uri, imas_filepath=None
-      )
+      config = imas_config.IMASConfig(imas_uri=imas_uri, imas_filepath=None)
       config.build_geometry()
 
   def test_IMAS_input_with_equilibrium_object(self):
@@ -154,6 +152,34 @@ class EquilibriumTest(parameterized.TestCase):
         AssertionError, 'mismatched between slice_time and slice_index'
     ):
       _check_geo_match(geo_at_0, geo_at_slice_from_index)
+
+  def test_IMAS_raises_if_required_geometry_field_missing(self):
+    equilibrium_in = loader.load_imas_data(
+        'ITERhybrid_COCOS17_IDS_ddv4.nc', 'equilibrium'
+    )
+    equilibrium_in.time_slice[0].profiles_1d.gm7 = np.array([])
+    config = imas_config.IMASConfig(
+        equilibrium_object=equilibrium_in, imas_filepath=None
+    )
+
+    with self.assertRaisesRegex(ValueError, r'profiles_1d\.gm7'):
+      config.build_geometry()
+
+  def test_IMAS_requires_volume_or_dvolume_dpsi(self):
+    equilibrium_in = loader.load_imas_data(
+        'ITERhybrid_COCOS17_IDS_ddv4.nc', 'equilibrium'
+    )
+    profiles_1d = equilibrium_in.time_slice[0].profiles_1d
+    profiles_1d.dvolume_dpsi = np.array([])
+    profiles_1d.volume = np.array([])
+    config = imas_config.IMASConfig(
+        equilibrium_object=equilibrium_in, imas_filepath=None
+    )
+
+    with self.assertRaisesRegex(
+        ValueError, r'profiles_1d\.dvolume_dpsi or profiles_1d\.volume'
+    ):
+      config.build_geometry()
 
   def test_IMAS_raises_if_slice_out_of_range(self):
     filename = 'ITERhybrid_COCOS17_IDS_ddv4.nc'

--- a/torax/_src/imas_tools/input/validation.py
+++ b/torax/_src/imas_tools/input/validation.py
@@ -41,6 +41,53 @@ def _validate_paths(
       logging.warning("The IDS is missing the %s quantity.", path)
 
 
+def validate_equilibrium_geometry_from_IMAS(
+    ids: ids_toplevel.IDSToplevel, slice_index: int
+) -> None:
+  """Validates quantities required to construct geometry from equilibrium."""
+  _validate_paths(
+      ids,
+      required_paths=(
+          "vacuum_toroidal_field.r0",
+          "vacuum_toroidal_field.b0",
+      ),
+      warning_paths=(),
+  )
+
+  time_slice = ids.time_slice[slice_index]
+  _validate_paths(
+      time_slice,
+      required_paths=(
+          "profiles_1d.psi",
+          "profiles_1d.phi",
+          "profiles_1d.r_inboard",
+          "profiles_1d.r_outboard",
+          "profiles_1d.f",
+          "profiles_1d.gm1",
+          "profiles_1d.gm2",
+          "profiles_1d.gm3",
+          "profiles_1d.gm4",
+          "profiles_1d.gm5",
+          "profiles_1d.gm7",
+          "profiles_1d.j_phi",
+          "profiles_1d.triangularity_upper",
+          "profiles_1d.triangularity_lower",
+          "profiles_1d.elongation",
+          "global_quantities.ip",
+          "global_quantities.magnetic_axis.z",
+          "boundary.minor_radius",
+          "boundary.type",
+      ),
+      warning_paths=(),
+  )
+
+  profiles_1d = time_slice.profiles_1d
+  if not (profiles_1d.dvolume_dpsi.has_value or profiles_1d.volume.has_value):
+    raise ValueError(
+        "The IDS must provide profiles_1d.dvolume_dpsi or profiles_1d.volume."
+    )
+
+
 def validate_profile_conditions_from_IMAS(
     ids: ids_toplevel.IDSToplevel,
 ) -> None:


### PR DESCRIPTION
Fixes #2409.

Validate the equilibrium quantities used by the IMAS geometry loader before geometry calculations begin. Missing required profiles such as `gm7` now raise a direct field-level error, while preserving the existing `dvolume_dpsi`/`volume` fallback.

Tests:
- `uv run pytest -q torax/_src/imas_tools/input/tests` (26 passed, 7 subtests passed)
- Pyink and isort checks pass
- `validation.py` passes Pylint