### PR TITLE
Add electron-ion collision time to outputs

### DIFF
--- a/torax/_src/output_tools/output_keys.py
+++ b/torax/_src/output_tools/output_keys.py
@@ -715,6 +715,9 @@ W_THERMAL_TOTAL: Final[OutputKey] = OutputKey(
 TAU_E: Final[OutputKey] = OutputKey(
     "tau_E", units=Units.SECOND, grid_type=GridType.SCALAR
 )
+TAU_EI: Final[OutputKey] = OutputKey(
+    "tau_ei", units=Units.SECOND, grid_type=GridType.CELL
+)
 H89P: Final[OutputKey] = OutputKey(
     "H89P", units=Units.DIMENSIONLESS, grid_type=GridType.SCALAR
 )

--- a/torax/_src/output_tools/post_processing.py
+++ b/torax/_src/output_tools/post_processing.py
@@ -31,6 +31,7 @@ from torax._src.geometry import geometry
 from torax._src.orchestration import sim_state as sim_state_lib
 from torax._src.output_tools import impurity_radiation
 from torax._src.output_tools import safety_factor_fit
+from torax._src.physics import collisions
 from torax._src.physics import formulas
 from torax._src.physics import psi_calculations
 from torax._src.physics import rotation
@@ -55,6 +56,7 @@ class PostProcessedOutputs:
     W_thermal_e: Electron thermal stored energy [J]
     W_thermal_total: Total thermal stored energy [J]
     tau_E: Thermal energy confinement time [s]
+    tau_ei: Electron-ion collision time on the cell grid [s]
     H89P: L-mode confinement quality factor with respect to the ITER89P scaling
       law derived from the ITER L-mode confinement database
     H98: H-mode confinement quality factor with respect to the ITER98y2 scaling
@@ -218,6 +220,7 @@ class PostProcessedOutputs:
   W_thermal_e: array_typing.FloatScalar
   W_thermal_total: array_typing.FloatScalar
   tau_E: array_typing.FloatScalar
+  tau_ei: array_typing.FloatVector
   H89P: array_typing.FloatScalar
   H98: array_typing.FloatScalar
   H97L: array_typing.FloatScalar
@@ -338,6 +341,7 @@ class PostProcessedOutputs:
         W_thermal_e=jnp.array(0.0, dtype=jax_utils.get_dtype()),
         W_thermal_total=jnp.array(0.0, dtype=jax_utils.get_dtype()),
         tau_E=jnp.array(0.0, dtype=jax_utils.get_dtype()),
+        tau_ei=jnp.zeros(geo.rho.shape),
         H89P=jnp.array(0.0, dtype=jax_utils.get_dtype()),
         H98=jnp.array(0.0, dtype=jax_utils.get_dtype()),
         H97L=jnp.array(0.0, dtype=jax_utils.get_dtype()),
@@ -797,6 +801,11 @@ def make_post_processed_outputs(
   )
 
   tau_E = internal_plasma_energy.W_thermal_total / P_loss
+  tau_ei = collisions.calculate_tau_ei(
+      sim_state.core_profiles.T_e.value,
+      sim_state.core_profiles.n_e.value,
+      sim_state.core_profiles.Z_eff,
+  )
 
   tauH89P = scaling_laws.calculate_scaling_law_confinement_time(
       sim_state.geometry, sim_state.core_profiles, P_loss, 'H89P'
@@ -962,6 +971,7 @@ def make_post_processed_outputs(
       W_thermal_e=internal_plasma_energy.W_thermal_e,
       W_thermal_total=internal_plasma_energy.W_thermal_total,
       tau_E=tau_E,
+      tau_ei=tau_ei,
       H89P=H89P,
       H98=H98,
       H97L=H97L,

--- a/torax/_src/output_tools/tests/output_keys_test.py
+++ b/torax/_src/output_tools/tests/output_keys_test.py
@@ -88,6 +88,8 @@ class OutputKeysTest(parameterized.TestCase):
         output_keys.PSI.grid_type, output_keys.GridType.CELL_PLUS_BOUNDARIES
     )
     self.assertEqual(output_keys.IP.grid_type, output_keys.GridType.SCALAR)
+    self.assertEqual(output_keys.TAU_EI.units, output_keys.Units.SECOND)
+    self.assertEqual(output_keys.TAU_EI.grid_type, output_keys.GridType.CELL)
     self.assertEqual(
         output_keys.TOROIDAL_ANGULAR_VELOCITY.grid_type,
         output_keys.GridType.CELL_PLUS_BOUNDARIES,

--- a/torax/_src/output_tools/tests/post_processing_test.py
+++ b/torax/_src/output_tools/tests/post_processing_test.py
@@ -27,6 +27,7 @@ from torax._src.neoclassical.bootstrap_current import base as bootstrap_current_
 from torax._src.orchestration import run_simulation
 from torax._src.orchestration import sim_state
 from torax._src.output_tools import post_processing
+from torax._src.physics import collisions
 from torax._src.sources import source_profiles as source_profiles_lib
 from torax._src.test_utils import default_configs
 from torax._src.test_utils import default_sources
@@ -238,6 +239,40 @@ class PostProcessingTest(parameterized.TestCase):
     self.assertEqual(
         post_processed_outputs.check_for_errors(), state.SimError.NO_ERROR
     )
+
+  def test_electron_ion_collision_time_output(self):
+    input_state = sim_state.SimState(
+        t=jnp.array(0.0),
+        dt=jnp.array(1e-3),
+        core_profiles=self.core_profiles,
+        core_transport=state.CoreTransport.zeros(self.geo),
+        core_sources=self.source_profiles,
+        geometry=self.geo,
+        solver_numeric_outputs=state.SolverNumericOutputs(
+            solver_error_state=np.array(0, jax_utils.get_int_dtype()),
+            outer_solver_iterations=np.array(0, jax_utils.get_int_dtype()),
+            inner_solver_iterations=np.array(0, jax_utils.get_int_dtype()),
+            sawtooth_crash=False,
+        ),
+        edge_outputs=None,
+        time_step_calculator_state=(
+            self.models.time_step_calculator.initial_state(self.runtime_params)
+        ),
+    )
+
+    previous_outputs = post_processing.PostProcessedOutputs.zeros(self.geo)
+    outputs = post_processing.make_post_processed_outputs(
+        sim_state=input_state,
+        runtime_params=self.runtime_params,
+        previous_post_processed_outputs=previous_outputs,
+    )
+    expected = collisions.calculate_tau_ei(
+        self.core_profiles.T_e.value,
+        self.core_profiles.n_e.value,
+        self.core_profiles.Z_eff,
+    )
+
+    np.testing.assert_allclose(outputs.tau_ei, expected)
 
   def test_current_outputs(self):
     """Checks calculation of current-related outputs."""

--- a/torax/_src/physics/collisions.py
+++ b/torax/_src/physics/collisions.py
@@ -27,6 +27,7 @@ Functions:
       electron-ion collisions.
     - calculate_log_lambda_ii: Calculates the Coulomb logarithm for ion-ion
       collisions.
+    - calculate_tau_ei: Calculates the electron-ion collision time.
     - calculate_tau_ii: Calculates the ion-ion collision time.
     - _calculate_weighted_Z_eff: Calculates ion mass weighted Z_eff used in
       the equipartion calculation.
@@ -243,6 +244,29 @@ def calculate_log_lambda_ii(
   # Rescale T_i to eV for specific form of formula.
   T_i_ev = T_i * 1e3
   return 30.0 - 0.5 * jnp.log(n_i) + 1.5 * jnp.log(T_i_ev) - 3.0 * jnp.log(Z_i)
+
+
+def calculate_tau_ei(
+    T_e: jax.Array,
+    n_e: jax.Array,
+    Z_eff: jax.Array,
+) -> jax.Array:
+  """Calculates the electron-ion collision time.
+
+  See Wesson 3rd edition p729. The Z=1 collision time is corrected by the
+  effective ion charge so that ``tau_ei = tau_e_Z1 / Z_eff``.
+
+  Args:
+    T_e: Electron temperature [keV].
+    n_e: Electron density [m^-3].
+    Z_eff: Effective ion charge [dimensionless].
+
+  Returns:
+    Electron-ion collision time [s].
+  """
+  log_lambda_ei = calculate_log_lambda_ei(T_e, n_e)
+  log_tau_e_Z1 = _calculate_log_tau_e_Z1(T_e, n_e, log_lambda_ei)
+  return jnp.exp(log_tau_e_Z1) / Z_eff
 
 
 def calculate_tau_ii(

--- a/torax/_src/physics/tests/collisions_test.py
+++ b/torax/_src/physics/tests/collisions_test.py
@@ -18,6 +18,7 @@ from absl.testing import absltest
 from absl.testing import parameterized
 from jax import numpy as jnp
 import numpy as np
+from torax._src import constants
 from torax._src import state
 from torax._src.fvm import cell_variable
 from torax._src.physics import collisions
@@ -65,6 +66,25 @@ class CollisionsTest(parameterized.TestCase):
     n_e = jnp.array(n_e)
     result = collisions.calculate_log_lambda_ee(T_e_kev, n_e)
     np.testing.assert_allclose(result, expected)
+
+  def test_calculate_tau_ei(self):
+    T_e = jnp.array([1.0, 2.0])
+    n_e = jnp.array([1.0e20, 2.0e20])
+    Z_eff = jnp.array([1.0, 2.0])
+
+    log_lambda_ei = collisions.calculate_log_lambda_ei(T_e, n_e)
+    expected = (
+        12.0
+        * np.pi**1.5
+        * constants.CONSTANTS.epsilon_0**2
+        * np.sqrt(constants.CONSTANTS.m_e / 2.0)
+        * (T_e * constants.CONSTANTS.keV_to_J) ** 1.5
+        / (n_e * Z_eff * constants.CONSTANTS.q_e**4 * log_lambda_ei)
+    )
+
+    np.testing.assert_allclose(
+        collisions.calculate_tau_ei(T_e, n_e, Z_eff), expected, rtol=1e-6
+    )
 
   @parameterized.parameters([
       dict(T_i_ev=1.0, n_i=1.0, Z_i=1.0, expected=30.0),


### PR DESCRIPTION
Fixes #2237.

Add the electron-ion collision time as a cell-grid post-processed output. The calculation reuses the existing Wesson electron-ion collision formulation and applies the effective-charge correction already used when deriving electron collisionality.

Changes:
- add `calculate_tau_ei(T_e, n_e, Z_eff)` in the collision physics utilities
- expose `tau_ei` in `PostProcessedOutputs` and xarray output with seconds metadata
- cover the formula, post-processing value, and output-key grid/unit metadata

Validation:
- 55 focused physics/output tests passed
- new collision-time, post-processing, and output-key tests passed
- `git diff --check`
